### PR TITLE
Bootstrap projects and add LogDbConnection extension

### DIFF
--- a/Extensions-Logging-Data.slnx
+++ b/Extensions-Logging-Data.slnx
@@ -42,7 +42,11 @@
   </Folder>
   <Folder Name="/benchmarks/" />
   <Folder Name="/examples/" />
-  <Folder Name="/src/" />
-  <Folder Name="/tests/" />
+  <Folder Name="/src/">
+    <Project Path="src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj" />
+  </Folder>
 </Solution>
 

--- a/src/Wolfgang.Extensions.Logging.Data/DbConnectionLoggerExtensions.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/DbConnectionLoggerExtensions.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data;
+
+/// <summary>
+/// Extension methods on <see cref="ILogger"/> for logging <see cref="DbConnection"/> instances.
+/// </summary>
+/// <remarks>
+/// The <see cref="DbConnection.ConnectionString"/> is parsed via
+/// <see cref="DbConnectionStringBuilder"/> and the <c>Password</c> and <c>Pwd</c> keys are
+/// removed before logging so credentials are never written to the log. All other keys,
+/// including the user name (<c>User ID</c>, <c>UID</c>, etc.), are preserved.
+/// </remarks>
+public static class DbConnectionLoggerExtensions
+{
+    private const string MessageTemplate =
+        "DbConnection {ConnectionType} Database={Database} DataSource={DataSource} ServerVersion={ServerVersion} State={State} ConnectionTimeout={ConnectionTimeout} ConnectionString={ConnectionString}";
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="connection"/> at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="connection">The connection to log.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="connection"/> is <see langword="null"/>.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// using var connection = new SqlConnection(connectionString);
+    /// await connection.OpenAsync();
+    /// logger.LogDbConnection(connection);
+    /// </code>
+    /// </example>
+    public static void LogDbConnection(this ILogger logger, DbConnection connection)
+    {
+        LogDbConnection(logger, connection, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="connection"/> at the
+    /// specified <paramref name="level"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="connection">The connection to log.</param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="connection"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbConnection(this ILogger logger, DbConnection connection, LogLevel level)
+    {
+        if (logger is null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        var redactedConnectionString = RedactConnectionString(connection.ConnectionString);
+        var serverVersion = TryGetServerVersion(connection);
+
+        logger.Log
+        (
+            level,
+            MessageTemplate,
+            connection.GetType().FullName,
+            connection.Database,
+            connection.DataSource,
+            serverVersion,
+            connection.State,
+            connection.ConnectionTimeout,
+            redactedConnectionString
+        );
+    }
+
+
+
+    /// <summary>
+    /// Parses <paramref name="connectionString"/> via <see cref="DbConnectionStringBuilder"/>
+    /// and removes the <c>Password</c> and <c>Pwd</c> keys (case-insensitive).
+    /// </summary>
+    /// <param name="connectionString">The raw connection string. May be <see langword="null"/> or empty.</param>
+    /// <returns>
+    /// The connection string with password keys removed, or <see cref="string.Empty"/> when the
+    /// input is null or empty.
+    /// </returns>
+    internal static string RedactConnectionString(string? connectionString)
+    {
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            return string.Empty;
+        }
+
+        var builder = new DbConnectionStringBuilder
+        {
+            ConnectionString = connectionString
+        };
+
+        if (builder.ContainsKey("Password"))
+        {
+            builder.Remove("Password");
+        }
+
+        if (builder.ContainsKey("Pwd"))
+        {
+            builder.Remove("Pwd");
+        }
+
+        return builder.ConnectionString ?? string.Empty;
+    }
+
+
+
+    private static string? TryGetServerVersion(DbConnection connection)
+    {
+        if (connection.State != ConnectionState.Open)
+        {
+            return null;
+        }
+
+        try
+        {
+            return connection.ServerVersion;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Wolfgang.Extensions.Logging.Data/Properties/AssemblyInfo.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Wolfgang.Extensions.Logging.Data.Tests.Unit")]

--- a/src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj
+++ b/src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net462;netstandard2.0;netstandard2.1;net10.0</TargetFrameworks>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+		<Version>0.1.0</Version>
+		<Title>$(AssemblyName)</Title>
+		<Authors>Chris Wolfgang</Authors>
+		<Description>Extension methods for ILogger and ILogger&lt;T&gt; that log DbConnection, DbCommand, DbParameter, and DbParameterCollection from System.Data.Common, with built-in secret redaction (passwords in connection strings, configurable parameter values).</Description>
+		<Copyright>Copyright 2026 Chris Wolfgang</Copyright>
+		<PackageProjectUrl>https://github.com/Chris-Wolfgang/Extensions-Logging-Data</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<AssemblyVersion>1.0.0</AssemblyVersion>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<SignAssembly>False</SignAssembly>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+		<Reference Include="System.Data" />
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+</Project>

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbConnectionLoggerExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbConnectionLoggerExtensionsTests.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit;
+
+public class DbConnectionLoggerExtensionsTests
+{
+    [Fact]
+    public void LogDbConnection_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var connection = new FakeDbConnection();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbConnection(connection));
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_with_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var connection = new FakeDbConnection();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbConnection(connection, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_when_connection_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbConnection(null!));
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_with_level_when_connection_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbConnection(null!, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_when_log_level_is_disabled_writes_nothing()
+    {
+        var logger = new RecordingLogger { MinimumLevel = LogLevel.Warning };
+        var connection = new FakeDbConnection();
+
+        logger.LogDbConnection(connection, LogLevel.Information);
+
+        Assert.Empty(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_default_overload_logs_at_information()
+    {
+        var logger = new RecordingLogger();
+        var connection = new FakeDbConnection();
+
+        logger.LogDbConnection(connection);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+    }
+
+
+
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public void LogDbConnection_logs_at_specified_level(LogLevel level)
+    {
+        var logger = new RecordingLogger();
+        var connection = new FakeDbConnection();
+
+        logger.LogDbConnection(connection, level);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(level, entry.Level);
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_includes_database_data_source_state_timeout_in_log_values()
+    {
+        var logger = new RecordingLogger();
+        var connection = new FakeDbConnection
+        {
+            DatabaseValue = "MyDb",
+            DataSourceValue = "tcp:server.example.com",
+            StateValue = ConnectionState.Open,
+            ServerVersionValue = "16.0.1000",
+            ConnectionTimeoutValue = 45
+        };
+
+        logger.LogDbConnection(connection);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal("MyDb", entry.GetValue("Database"));
+        Assert.Equal("tcp:server.example.com", entry.GetValue("DataSource"));
+        Assert.Equal(ConnectionState.Open, entry.GetValue("State"));
+        Assert.Equal(45, entry.GetValue("ConnectionTimeout"));
+        Assert.Equal("16.0.1000", entry.GetValue("ServerVersion"));
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_includes_connection_type_full_name()
+    {
+        var logger = new RecordingLogger();
+        var connection = new FakeDbConnection();
+
+        logger.LogDbConnection(connection);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(typeof(FakeDbConnection).FullName, entry.GetValue("ConnectionType"));
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_when_connection_is_closed_logs_null_server_version()
+    {
+        var logger = new RecordingLogger();
+        var connection = new FakeDbConnection
+        {
+            StateValue = ConnectionState.Closed,
+            ServerVersionValue = "ignored-because-closed"
+        };
+
+        logger.LogDbConnection(connection);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Null(entry.GetValue("ServerVersion"));
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_when_server_version_throws_InvalidOperationException_logs_null_server_version()
+    {
+        var logger = new RecordingLogger();
+        var connection = new FakeDbConnection
+        {
+            StateValue = ConnectionState.Open,
+            ServerVersionException = new InvalidOperationException("not available")
+        };
+
+        logger.LogDbConnection(connection);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Null(entry.GetValue("ServerVersion"));
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_redacts_password_from_logged_connection_string()
+    {
+        var logger = new RecordingLogger();
+        var connection = new FakeDbConnection
+        {
+            ConnectionString = "Server=foo;User ID=bob;Password=topsecret"
+        };
+
+        logger.LogDbConnection(connection);
+
+        var entry = Assert.Single(logger.Entries);
+        var redacted = (string)entry.GetValue("ConnectionString")!;
+        Assert.DoesNotContain("topsecret", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("bob", redacted, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Fact]
+    public void RedactConnectionString_with_null_returns_empty_string()
+    {
+        Assert.Equal(string.Empty, DbConnectionLoggerExtensions.RedactConnectionString(connectionString: null));
+    }
+
+
+
+    [Fact]
+    public void RedactConnectionString_with_empty_returns_empty_string()
+    {
+        Assert.Equal(string.Empty, DbConnectionLoggerExtensions.RedactConnectionString(string.Empty));
+    }
+
+
+
+    [Fact]
+    public void RedactConnectionString_removes_Password_key()
+    {
+        var redacted = DbConnectionLoggerExtensions.RedactConnectionString("Server=foo;Password=secret");
+
+        var parsed = new DbConnectionStringBuilder { ConnectionString = redacted };
+        Assert.False(parsed.ContainsKey("Password"));
+        Assert.True(parsed.ContainsKey("Server"));
+    }
+
+
+
+    [Fact]
+    public void RedactConnectionString_removes_Pwd_key()
+    {
+        var redacted = DbConnectionLoggerExtensions.RedactConnectionString("Server=foo;Pwd=secret");
+
+        var parsed = new DbConnectionStringBuilder { ConnectionString = redacted };
+        Assert.False(parsed.ContainsKey("Pwd"));
+        Assert.True(parsed.ContainsKey("Server"));
+    }
+
+
+
+    [Theory]
+    [InlineData("PASSWORD")]
+    [InlineData("password")]
+    [InlineData("PassWord")]
+    public void RedactConnectionString_removes_password_case_insensitively(string casing)
+    {
+        var redacted = DbConnectionLoggerExtensions.RedactConnectionString($"Server=foo;{casing}=secret");
+
+        Assert.DoesNotContain("secret", redacted, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Theory]
+    [InlineData("PWD")]
+    [InlineData("pwd")]
+    [InlineData("Pwd")]
+    public void RedactConnectionString_removes_pwd_case_insensitively(string casing)
+    {
+        var redacted = DbConnectionLoggerExtensions.RedactConnectionString($"Server=foo;{casing}=secret");
+
+        Assert.DoesNotContain("secret", redacted, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Fact]
+    public void RedactConnectionString_keeps_user_id_value()
+    {
+        var redacted = DbConnectionLoggerExtensions.RedactConnectionString("Server=foo;User ID=bob;Password=secret");
+
+        var parsed = new DbConnectionStringBuilder { ConnectionString = redacted };
+        Assert.True(parsed.ContainsKey("User ID"));
+        Assert.Equal("bob", parsed["User ID"]);
+    }
+
+
+
+    [Fact]
+    public void RedactConnectionString_with_no_password_preserves_all_keys()
+    {
+        var redacted = DbConnectionLoggerExtensions.RedactConnectionString("Server=foo;User ID=bob");
+
+        var parsed = new DbConnectionStringBuilder { ConnectionString = redacted };
+        Assert.Equal("foo", parsed["Server"]);
+        Assert.Equal("bob", parsed["User ID"]);
+    }
+
+
+
+    [Fact]
+    public void RedactConnectionString_with_both_Password_and_Pwd_removes_both_values()
+    {
+        var redacted = DbConnectionLoggerExtensions.RedactConnectionString("Server=foo;Password=p1;Pwd=p2");
+
+        Assert.DoesNotContain("p1", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("p2", redacted, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbConnectionLoggerExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbConnectionLoggerExtensionsTests.cs
@@ -235,20 +235,10 @@ public class DbConnectionLoggerExtensionsTests
     [InlineData("PASSWORD")]
     [InlineData("password")]
     [InlineData("PassWord")]
-    public void RedactConnectionString_removes_password_case_insensitively(string casing)
-    {
-        var redacted = DbConnectionLoggerExtensions.RedactConnectionString($"Server=foo;{casing}=secret");
-
-        Assert.DoesNotContain("secret", redacted, StringComparison.OrdinalIgnoreCase);
-    }
-
-
-
-    [Theory]
     [InlineData("PWD")]
     [InlineData("pwd")]
     [InlineData("Pwd")]
-    public void RedactConnectionString_removes_pwd_case_insensitively(string casing)
+    public void RedactConnectionString_removes_password_or_pwd_case_insensitively(string casing)
     {
         var redacted = DbConnectionLoggerExtensions.RedactConnectionString($"Server=foo;{casing}=secret");
 

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbConnection.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbConnection.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Data;
+using System.Data.Common;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+internal sealed class FakeDbConnection : DbConnection
+{
+    private string _connectionString = string.Empty;
+
+#pragma warning disable CS8765 // Base ConnectionString uses [AllowNull] on the setter on net5+; accept null and coalesce.
+    public override string ConnectionString
+    {
+        get => _connectionString;
+        set => _connectionString = value ?? string.Empty;
+    }
+#pragma warning restore CS8765
+
+    public string DatabaseValue { get; set; } = string.Empty;
+
+    public string DataSourceValue { get; set; } = string.Empty;
+
+    public string ServerVersionValue { get; set; } = string.Empty;
+
+    public ConnectionState StateValue { get; set; } = ConnectionState.Closed;
+
+    public int ConnectionTimeoutValue { get; set; } = 30;
+
+    public Exception? ServerVersionException { get; set; }
+
+    public override string Database => DatabaseValue;
+
+    public override string DataSource => DataSourceValue;
+
+    public override string ServerVersion
+    {
+        get
+        {
+            if (ServerVersionException is not null)
+            {
+                throw ServerVersionException;
+            }
+
+            return ServerVersionValue;
+        }
+    }
+
+    public override ConnectionState State => StateValue;
+
+    public override int ConnectionTimeout => ConnectionTimeoutValue;
+
+    public override void ChangeDatabase(string databaseName) => DatabaseValue = databaseName;
+
+    public override void Close() => StateValue = ConnectionState.Closed;
+
+    public override void Open() => StateValue = ConnectionState.Open;
+
+    protected override DbCommand CreateDbCommand() => throw new NotSupportedException();
+
+    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new NotSupportedException();
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/LogEntry.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/LogEntry.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+internal sealed class LogEntry
+{
+    public LogEntry
+    (
+        LogLevel level,
+        EventId eventId,
+        string message,
+        Exception? exception,
+        IReadOnlyList<KeyValuePair<string, object?>>? values
+    )
+    {
+        Level = level;
+        EventId = eventId;
+        Message = message;
+        Exception = exception;
+        Values = values;
+    }
+
+    public LogLevel Level { get; }
+
+    public EventId EventId { get; }
+
+    public string Message { get; }
+
+    public Exception? Exception { get; }
+
+    public IReadOnlyList<KeyValuePair<string, object?>>? Values { get; }
+
+    public object? GetValue(string name)
+    {
+        if (Values is null)
+        {
+            return null;
+        }
+
+        foreach (var kvp in Values)
+        {
+            if (string.Equals(kvp.Key, name, StringComparison.Ordinal))
+            {
+                return kvp.Value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/RecordingLogger.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/RecordingLogger.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+internal sealed class RecordingLogger : ILogger
+{
+    public List<LogEntry> Entries { get; } = new List<LogEntry>();
+
+    public LogLevel MinimumLevel { get; set; } = LogLevel.Trace;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel >= MinimumLevel;
+
+    public void Log<TState>
+    (
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter
+    )
+    {
+        var message = formatter(state, exception);
+        var values = state as IReadOnlyList<KeyValuePair<string, object?>>;
+        Entries.Add(new LogEntry(logLevel, eventId, message, exception, values));
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net462;net47;net471;net472;net48;net481;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+
+    <NoWarn>NU1701</NoWarn>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.Logging.Data\Wolfgang.Extensions.Logging.Data.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Bootstraps the source and unit-test projects (`Wolfgang.Extensions.Logging.Data`) with the multi-TFM matrix and analyzer/test stack used across the rest of the repos.
- Adds the first ILogger extension: `LogDbConnection` (two overloads — default Information level, and explicit LogLevel).
- Emits one structured log entry per call with named template fields so log sinks can index/filter (`ConnectionType`, `Database`, `DataSource`, `ServerVersion`, `State`, `ConnectionTimeout`, `ConnectionString`).
- Connection string is parsed via `DbConnectionStringBuilder` and `Password` / `Pwd` keys (case-insensitive) are removed before logging. Username (`User ID`, `UID`, etc.) is preserved.
- `ServerVersion` is only read when `State == Open`; if the provider throws `InvalidOperationException` it logs as null instead of bubbling.

## Test plan
- [x] Release build clean across all 4 source TFMs (net462, netstandard2.0, netstandard2.1, net10.0) — 0 warnings, 0 errors
- [x] All 30 unit tests pass on net462, net47, net471, net472, net48, net481, net6.0, net7.0, net8.0, net9.0, net10.0
- [x] net5.0 returns exit 0 (matches the In-Memory Logger pattern; xunit discoverer doesn't load on net5.0 with current xunit/runner versions but CI accepts the clean exit)
- [x] Coverage: null guards, level filtering (each LogLevel), redaction (Password / Pwd / case variants / both keys present), preservation of non-secret keys, ServerVersion edge cases (closed connection, throwing provider), null ConnectionString
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)