### PR TITLE
Add LogDbCommand extension methods

### DIFF
--- a/src/Wolfgang.Extensions.Logging.Data/DbCommandLoggerExtensions.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/DbCommandLoggerExtensions.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data;
+
+/// <summary>
+/// Extension methods on <see cref="ILogger"/> for logging <see cref="DbCommand"/> instances.
+/// </summary>
+/// <remarks>
+/// Each call emits a single structured log entry. The command's <see cref="DbCommand.Parameters"/>
+/// are automatically captured into <see cref="LoggedDbParameter"/> snapshots and included in the entry.
+/// Callers can pass a list of parameter names whose values should be replaced with the literal string
+/// <c>[REDACTED]</c>; matching is case-insensitive and tolerant of provider prefixes
+/// (<c>@name</c>, <c>:name</c>, <c>?name</c>, and <c>name</c> are all equivalent).
+/// </remarks>
+public static class DbCommandLoggerExtensions
+{
+    private const string MessageTemplate =
+        "DbCommand {CommandType} CommandText={CommandText} CommandTimeout={CommandTimeout} Parameters={Parameters}";
+
+    private const string RedactedValue = "[REDACTED]";
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="command"/> and its parameters at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="command">The command to log.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="command"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbCommand(this ILogger logger, DbCommand command)
+    {
+        LogDbCommand(logger, command, excludedParameterNames: null, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="command"/> and its parameters at
+    /// the specified <paramref name="level"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="command">The command to log.</param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="command"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbCommand(this ILogger logger, DbCommand command, LogLevel level)
+    {
+        LogDbCommand(logger, command, excludedParameterNames: null, level);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="command"/> and its parameters at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information, redacting the values of any
+    /// parameters whose names appear in <paramref name="excludedParameterNames"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="command">The command to log.</param>
+    /// <param name="excludedParameterNames">
+    /// Parameter names whose values should be replaced with the literal string <c>[REDACTED]</c>.
+    /// Matching is case-insensitive and ignores provider prefixes (<c>@</c>, <c>:</c>, <c>?</c>).
+    /// May be <see langword="null"/> for no redaction.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="command"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbCommand(this ILogger logger, DbCommand command, IEnumerable<string>? excludedParameterNames)
+    {
+        LogDbCommand(logger, command, excludedParameterNames, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="command"/> and its parameters at
+    /// the specified <paramref name="level"/>, redacting the values of any parameters whose names
+    /// appear in <paramref name="excludedParameterNames"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="command">The command to log.</param>
+    /// <param name="excludedParameterNames">
+    /// Parameter names whose values should be replaced with the literal string <c>[REDACTED]</c>.
+    /// Matching is case-insensitive and ignores provider prefixes (<c>@</c>, <c>:</c>, <c>?</c>).
+    /// May be <see langword="null"/> for no redaction.
+    /// </param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="command"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbCommand
+    (
+        this ILogger logger,
+        DbCommand command,
+        IEnumerable<string>? excludedParameterNames,
+        LogLevel level
+    )
+    {
+        if (logger is null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (command is null)
+        {
+            throw new ArgumentNullException(nameof(command));
+        }
+
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        var snapshots = SnapshotParameters(command.Parameters, excludedParameterNames);
+
+        logger.Log
+        (
+            level,
+            MessageTemplate,
+            command.CommandType,
+            command.CommandText,
+            command.CommandTimeout,
+            snapshots
+        );
+    }
+
+
+
+    internal static List<LoggedDbParameter> SnapshotParameters
+    (
+        DbParameterCollection? parameters,
+        IEnumerable<string>? excludedParameterNames
+    )
+    {
+        if (parameters is null)
+        {
+            return new List<LoggedDbParameter>();
+        }
+
+        var excluded = NormalizeExcluded(excludedParameterNames);
+        var result = new List<LoggedDbParameter>(parameters.Count);
+
+        foreach (DbParameter p in parameters)
+        {
+            var redact = ShouldRedact(p.ParameterName, excluded);
+            result.Add
+            (
+                new LoggedDbParameter
+                (
+                    p.ParameterName,
+                    p.DbType,
+                    p.Direction,
+                    p.Size,
+                    p.Precision,
+                    p.Scale,
+                    p.IsNullable,
+                    redact ? RedactedValue : p.Value
+                )
+            );
+        }
+
+        return result;
+    }
+
+
+
+    internal static HashSet<string> NormalizeExcluded(IEnumerable<string>? excludedParameterNames)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (excludedParameterNames is null)
+        {
+            return set;
+        }
+
+        foreach (var name in excludedParameterNames)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                continue;
+            }
+
+            set.Add(StripPrefix(name));
+        }
+
+        return set;
+    }
+
+
+
+    internal static bool ShouldRedact(string? parameterName, HashSet<string> excluded)
+    {
+        if (excluded.Count == 0)
+        {
+            return false;
+        }
+
+        return excluded.Contains(StripPrefix(parameterName ?? string.Empty));
+    }
+
+
+
+    internal static string StripPrefix(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return string.Empty;
+        }
+
+        var first = name[0];
+        if (first == '@' || first == ':' || first == '?')
+        {
+            return name.Substring(1);
+        }
+
+        return name;
+    }
+}

--- a/src/Wolfgang.Extensions.Logging.Data/LoggedDbParameter.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/LoggedDbParameter.cs
@@ -1,0 +1,75 @@
+using System.Data;
+
+namespace Wolfgang.Extensions.Logging.Data;
+
+/// <summary>
+/// Immutable snapshot of a <see cref="System.Data.Common.DbParameter"/> captured for structured logging.
+/// </summary>
+/// <remarks>
+/// <see cref="Value"/> is set to the literal string <c>[REDACTED]</c> when the parameter's name matches
+/// an entry in the caller-supplied excluded-names list passed to
+/// <see cref="DbCommandLoggerExtensions"/>; all other metadata is preserved.
+/// </remarks>
+public sealed class LoggedDbParameter
+{
+    /// <summary>
+    /// Initializes a new <see cref="LoggedDbParameter"/>.
+    /// </summary>
+    /// <param name="name">The parameter name (including any provider prefix such as <c>@</c>).</param>
+    /// <param name="dbType">The <see cref="System.Data.DbType"/> of the parameter.</param>
+    /// <param name="direction">The <see cref="ParameterDirection"/>.</param>
+    /// <param name="size">The size in bytes (or characters for string types).</param>
+    /// <param name="precision">The numeric precision.</param>
+    /// <param name="scale">The numeric scale.</param>
+    /// <param name="isNullable">Whether the parameter accepts <see langword="null"/>.</param>
+    /// <param name="value">The parameter value, or the redaction marker if the value was redacted.</param>
+    public LoggedDbParameter
+    (
+        string name,
+        DbType dbType,
+        ParameterDirection direction,
+        int size,
+        byte precision,
+        byte scale,
+        bool isNullable,
+        object? value
+    )
+    {
+        Name = name;
+        DbType = dbType;
+        Direction = direction;
+        Size = size;
+        Precision = precision;
+        Scale = scale;
+        IsNullable = isNullable;
+        Value = value;
+    }
+
+    /// <summary>The parameter name as reported by the source <c>DbParameter</c>.</summary>
+    public string Name { get; }
+
+    /// <summary>The <see cref="System.Data.DbType"/> of the parameter.</summary>
+    public DbType DbType { get; }
+
+    /// <summary>The <see cref="ParameterDirection"/> (Input, Output, etc.).</summary>
+    public ParameterDirection Direction { get; }
+
+    /// <summary>The size in bytes (or characters for string types).</summary>
+    public int Size { get; }
+
+    /// <summary>The numeric precision.</summary>
+    public byte Precision { get; }
+
+    /// <summary>The numeric scale.</summary>
+    public byte Scale { get; }
+
+    /// <summary>Whether the parameter accepts <see langword="null"/>.</summary>
+    public bool IsNullable { get; }
+
+    /// <summary>The parameter value, or the literal <c>[REDACTED]</c> marker when redacted.</summary>
+    public object? Value { get; }
+
+    /// <inheritdoc />
+    public override string ToString()
+        => $"{Name}={Value ?? "null"} (DbType={DbType}, Direction={Direction}, Size={Size}, Precision={Precision}, Scale={Scale}, IsNullable={IsNullable})";
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbCommandLoggerExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbCommandLoggerExtensionsTests.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit;
+
+public class DbCommandLoggerExtensionsTests
+{
+    private static FakeDbCommand CreateCommand(string commandText = "SELECT 1", CommandType type = CommandType.Text, int timeout = 30)
+    {
+        return new FakeDbCommand
+        {
+            CommandText = commandText,
+            CommandType = type,
+            CommandTimeout = timeout
+        };
+    }
+
+
+
+    private static FakeDbParameter AddParameter(FakeDbCommand command, string name, object? value, DbType dbType = DbType.String)
+    {
+        var p = new FakeDbParameter
+        {
+            ParameterName = name,
+            Value = value,
+            DbType = dbType
+        };
+        command.Parameters.Add(p);
+        return p;
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var command = CreateCommand();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbCommand(command));
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_with_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var command = CreateCommand();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbCommand(command, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_with_excluded_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var command = CreateCommand();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbCommand(command, new[] { "@p" }));
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_with_excluded_and_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var command = CreateCommand();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbCommand(command, new[] { "@p" }, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_when_command_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbCommand(command: null!));
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_with_level_when_command_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbCommand(null!, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_when_log_level_is_disabled_writes_nothing()
+    {
+        var logger = new RecordingLogger { MinimumLevel = LogLevel.Warning };
+        var command = CreateCommand();
+
+        logger.LogDbCommand(command, LogLevel.Information);
+
+        Assert.Empty(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_default_overload_logs_at_information()
+    {
+        var logger = new RecordingLogger();
+        var command = CreateCommand();
+
+        logger.LogDbCommand(command);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+    }
+
+
+
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public void LogDbCommand_logs_at_specified_level(LogLevel level)
+    {
+        var logger = new RecordingLogger();
+        var command = CreateCommand();
+
+        logger.LogDbCommand(command, level);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(level, entry.Level);
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_includes_command_text_type_and_timeout()
+    {
+        var logger = new RecordingLogger();
+        var command = CreateCommand("EXEC GetUser @id", CommandType.StoredProcedure, 60);
+
+        logger.LogDbCommand(command);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal("EXEC GetUser @id", entry.GetValue("CommandText"));
+        Assert.Equal(CommandType.StoredProcedure, entry.GetValue("CommandType"));
+        Assert.Equal(60, entry.GetValue("CommandTimeout"));
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_with_empty_parameter_collection_logs_empty_list()
+    {
+        var logger = new RecordingLogger();
+        var command = CreateCommand();
+
+        logger.LogDbCommand(command);
+
+        var entry = Assert.Single(logger.Entries);
+        var snapshots = (IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!;
+        Assert.Empty(snapshots);
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_includes_all_parameters_in_log_entry()
+    {
+        var logger = new RecordingLogger();
+        var command = CreateCommand();
+        AddParameter(command, "@id", 42, DbType.Int32);
+        AddParameter(command, "@name", "alice", DbType.String);
+        AddParameter(command, "@active", value: true, DbType.Boolean);
+
+        logger.LogDbCommand(command);
+
+        var entry = Assert.Single(logger.Entries);
+        var snapshots = (IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!;
+        Assert.Equal(3, snapshots.Count);
+        Assert.Equal("@id", snapshots[0].Name);
+        Assert.Equal(42, snapshots[0].Value);
+        Assert.Equal("@name", snapshots[1].Name);
+        Assert.Equal("alice", snapshots[1].Value);
+        Assert.Equal("@active", snapshots[2].Name);
+        Assert.Equal(true, snapshots[2].Value);
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_snapshot_captures_full_metadata_for_each_parameter()
+    {
+        var logger = new RecordingLogger();
+        var command = CreateCommand();
+        var p = new FakeDbParameter
+        {
+            ParameterName = "@total",
+            DbType = DbType.Decimal,
+            Direction = ParameterDirection.InputOutput,
+            Size = 9,
+            Precision = 18,
+            Scale = 4,
+            IsNullable = true,
+            Value = 12.34m
+        };
+        command.Parameters.Add(p);
+
+        logger.LogDbCommand(command);
+
+        var entry = Assert.Single(logger.Entries);
+        var snap = ((IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!).Single();
+        Assert.Equal("@total", snap.Name);
+        Assert.Equal(DbType.Decimal, snap.DbType);
+        Assert.Equal(ParameterDirection.InputOutput, snap.Direction);
+        Assert.Equal(9, snap.Size);
+        Assert.Equal(18, snap.Precision);
+        Assert.Equal(4, snap.Scale);
+        Assert.True(snap.IsNullable);
+        Assert.Equal(12.34m, snap.Value);
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_redacts_excluded_parameter_value_only()
+    {
+        var logger = new RecordingLogger();
+        var command = CreateCommand();
+        AddParameter(command, "@user", "alice");
+        AddParameter(command, "@password", "secret");
+
+        logger.LogDbCommand(command, new[] { "@password" });
+
+        var entry = Assert.Single(logger.Entries);
+        var snaps = (IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!;
+        Assert.Equal("alice", snaps[0].Value);
+        Assert.Equal("[REDACTED]", snaps[1].Value);
+        Assert.Equal("@password", snaps[1].Name);
+        Assert.Equal(DbType.String, snaps[1].DbType);
+    }
+
+
+
+    [Theory]
+    [InlineData("@password")]
+    [InlineData("password")]
+    [InlineData("PASSWORD")]
+    [InlineData("PassWord")]
+    [InlineData(":password")]
+    [InlineData("?password")]
+    public void LogDbCommand_excluded_name_matches_case_insensitively_and_ignores_prefix(string excludedName)
+    {
+        var logger = new RecordingLogger();
+        var command = CreateCommand();
+        AddParameter(command, "@password", "secret");
+
+        logger.LogDbCommand(command, new[] { excludedName });
+
+        var entry = Assert.Single(logger.Entries);
+        var snap = ((IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!).Single();
+        Assert.Equal("[REDACTED]", snap.Value);
+    }
+
+
+
+    [Theory]
+    [InlineData("@password")]
+    [InlineData(":password")]
+    [InlineData("?password")]
+    [InlineData("password")]
+    public void LogDbCommand_redacts_parameter_regardless_of_actual_prefix(string actualName)
+    {
+        var logger = new RecordingLogger();
+        var command = CreateCommand();
+        AddParameter(command, actualName, "secret");
+
+        logger.LogDbCommand(command, new[] { "password" });
+
+        var entry = Assert.Single(logger.Entries);
+        var snap = ((IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!).Single();
+        Assert.Equal("[REDACTED]", snap.Value);
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_with_null_excluded_does_not_redact()
+    {
+        var logger = new RecordingLogger();
+        var command = CreateCommand();
+        AddParameter(command, "@password", "secret");
+
+        logger.LogDbCommand(command, excludedParameterNames: null);
+
+        var entry = Assert.Single(logger.Entries);
+        var snap = ((IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!).Single();
+        Assert.Equal("secret", snap.Value);
+    }
+
+
+
+    [Fact]
+    public void LogDbCommand_with_excluded_and_level_uses_both()
+    {
+        var logger = new RecordingLogger();
+        var command = CreateCommand();
+        AddParameter(command, "@p", "v");
+
+        logger.LogDbCommand(command, new[] { "p" }, LogLevel.Warning);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        var snap = ((IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!).Single();
+        Assert.Equal("[REDACTED]", snap.Value);
+    }
+
+
+
+    // ---- Internal helper tests ----
+
+    [Fact]
+    public void StripPrefix_strips_at_sign() => Assert.Equal("name", DbCommandLoggerExtensions.StripPrefix("@name"));
+
+
+
+    [Fact]
+    public void StripPrefix_strips_colon() => Assert.Equal("name", DbCommandLoggerExtensions.StripPrefix(":name"));
+
+
+
+    [Fact]
+    public void StripPrefix_strips_question_mark() => Assert.Equal("name", DbCommandLoggerExtensions.StripPrefix("?name"));
+
+
+
+    [Fact]
+    public void StripPrefix_leaves_other_first_characters_alone() => Assert.Equal("name", DbCommandLoggerExtensions.StripPrefix("name"));
+
+
+
+    [Fact]
+    public void StripPrefix_with_empty_returns_empty() => Assert.Equal(string.Empty, DbCommandLoggerExtensions.StripPrefix(string.Empty));
+
+
+
+    [Fact]
+    public void StripPrefix_with_only_prefix_returns_empty() => Assert.Equal(string.Empty, DbCommandLoggerExtensions.StripPrefix("@"));
+
+
+
+    [Fact]
+    public void NormalizeExcluded_with_null_returns_empty_set()
+    {
+        var set = DbCommandLoggerExtensions.NormalizeExcluded(excludedParameterNames: null);
+        Assert.Empty(set);
+    }
+
+
+
+    [Fact]
+    public void NormalizeExcluded_strips_prefix_and_lowercases_for_match()
+    {
+        var set = DbCommandLoggerExtensions.NormalizeExcluded(new[] { "@Password", ":SECRET" });
+        Assert.Contains("password", set);
+        Assert.Contains("secret", set);
+        Assert.True(set.Contains("PASSWORD"));
+        Assert.True(set.Contains("Secret"));
+    }
+
+
+
+    [Fact]
+    public void NormalizeExcluded_skips_null_and_empty_entries()
+    {
+        var set = DbCommandLoggerExtensions.NormalizeExcluded(new[] { null!, string.Empty, "real" });
+        Assert.Single(set);
+        Assert.Contains("real", set);
+    }
+
+
+
+    [Fact]
+    public void ShouldRedact_with_empty_excluded_returns_false()
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        Assert.False(DbCommandLoggerExtensions.ShouldRedact("@anything", set));
+    }
+
+
+
+    [Fact]
+    public void ShouldRedact_with_null_parameter_name_returns_false_when_no_empty_excluded()
+    {
+        var set = DbCommandLoggerExtensions.NormalizeExcluded(new[] { "real" });
+        Assert.False(DbCommandLoggerExtensions.ShouldRedact(parameterName: null, set));
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbCommand.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbCommand.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Data;
+using System.Data.Common;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+internal sealed class FakeDbCommand : DbCommand
+{
+    private readonly FakeDbParameterCollection _parameters = new FakeDbParameterCollection();
+
+#pragma warning disable CS8765 // Base CommandText setter accepts null on net5+; coalesce instead.
+    public override string CommandText
+    {
+        get => _commandText;
+        set => _commandText = value ?? string.Empty;
+    }
+#pragma warning restore CS8765
+
+    private string _commandText = string.Empty;
+
+    public override int CommandTimeout { get; set; } = 30;
+
+    public override CommandType CommandType { get; set; } = CommandType.Text;
+
+    public override bool DesignTimeVisible { get; set; }
+
+    public override UpdateRowSource UpdatedRowSource { get; set; }
+
+    protected override DbConnection? DbConnection { get; set; }
+
+    protected override DbParameterCollection DbParameterCollection => _parameters;
+
+    protected override DbTransaction? DbTransaction { get; set; }
+
+    public override void Cancel() => throw new NotSupportedException();
+
+    public override int ExecuteNonQuery() => throw new NotSupportedException();
+
+    public override object? ExecuteScalar() => throw new NotSupportedException();
+
+    public override void Prepare() => throw new NotSupportedException();
+
+    protected override DbParameter CreateDbParameter() => new FakeDbParameter();
+
+    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => throw new NotSupportedException();
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbParameter.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbParameter.cs
@@ -1,0 +1,47 @@
+using System.Data;
+using System.Data.Common;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+internal sealed class FakeDbParameter : DbParameter
+{
+    public override DbType DbType { get; set; }
+
+    public override ParameterDirection Direction { get; set; } = ParameterDirection.Input;
+
+    public override bool IsNullable { get; set; }
+
+#pragma warning disable CS8765 // Base ParameterName setter accepts null on net5+; coalesce instead.
+    public override string ParameterName
+    {
+        get => _parameterName;
+        set => _parameterName = value ?? string.Empty;
+    }
+#pragma warning restore CS8765
+
+    private string _parameterName = string.Empty;
+
+    public override int Size { get; set; }
+
+#pragma warning disable CS8765 // Base SourceColumn setter accepts null on net5+; coalesce instead.
+    public override string SourceColumn
+    {
+        get => _sourceColumn;
+        set => _sourceColumn = value ?? string.Empty;
+    }
+#pragma warning restore CS8765
+
+    private string _sourceColumn = string.Empty;
+
+    public override bool SourceColumnNullMapping { get; set; }
+
+    public override DataRowVersion SourceVersion { get; set; } = DataRowVersion.Current;
+
+    public override object? Value { get; set; }
+
+    public override byte Precision { get; set; }
+
+    public override byte Scale { get; set; }
+
+    public override void ResetDbType() => DbType = DbType.Object;
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbParameterCollection.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbParameterCollection.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+internal sealed class FakeDbParameterCollection : DbParameterCollection
+{
+    private readonly List<DbParameter> _items = new List<DbParameter>();
+
+    public override int Count => _items.Count;
+
+    public override object SyncRoot => ((ICollection)_items).SyncRoot;
+
+    public override int Add(object value)
+    {
+        _items.Add((DbParameter)value);
+        return _items.Count - 1;
+    }
+
+    public override void AddRange(Array values)
+    {
+        foreach (var v in values)
+        {
+            Add(v!);
+        }
+    }
+
+    public override void Clear() => _items.Clear();
+
+    public override bool Contains(object value) => _items.Contains((DbParameter)value);
+
+    public override bool Contains(string value) => IndexOf(value) >= 0;
+
+    public override void CopyTo(Array array, int index) => ((ICollection)_items).CopyTo(array, index);
+
+    public override IEnumerator GetEnumerator() => _items.GetEnumerator();
+
+    public override int IndexOf(object value) => _items.IndexOf((DbParameter)value);
+
+    public override int IndexOf(string parameterName)
+    {
+        for (var i = 0; i < _items.Count; i++)
+        {
+            if (string.Equals(_items[i].ParameterName, parameterName, StringComparison.OrdinalIgnoreCase))
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public override void Insert(int index, object value) => _items.Insert(index, (DbParameter)value);
+
+    public override void Remove(object value) => _items.Remove((DbParameter)value);
+
+    public override void RemoveAt(int index) => _items.RemoveAt(index);
+
+    public override void RemoveAt(string parameterName)
+    {
+        var i = IndexOf(parameterName);
+        if (i >= 0)
+        {
+            RemoveAt(i);
+        }
+    }
+
+    protected override DbParameter GetParameter(int index) => _items[index];
+
+    protected override DbParameter GetParameter(string parameterName) => _items[IndexOf(parameterName)];
+
+    protected override void SetParameter(int index, DbParameter value) => _items[index] = value;
+
+    protected override void SetParameter(string parameterName, DbParameter value) => _items[IndexOf(parameterName)] = value;
+}


### PR DESCRIPTION
## Summary
- Adds `LogDbCommand` (four overloads) — emits one structured entry per call capturing CommandText, CommandType, CommandTimeout, and a snapshot of every parameter.
- Introduces `LoggedDbParameter` as the public, immutable per-parameter snapshot type so structured sinks (Serilog/Seq/etc.) can serialize each parameter's metadata cleanly.
- Excluded-name matching is **case-insensitive** and tolerant of provider prefixes — `@password`, `:password`, `?password`, and `password` are all equivalent. Only the value is replaced with the literal `[REDACTED]`; name, DbType, direction, size, precision, scale, and IsNullable are preserved.
- Reusable test infrastructure (`FakeDbCommand`, `FakeDbParameter`, `FakeDbParameterCollection`) which the next two extensions (LogDbParameter, LogDbParameterCollection) will share.

## Stacked on Extensions-Logging-Data#4
This PR is based on `initial-dev`, not `main`. The diff currently includes the LogDbConnection commit from #4; once that merges to main, GitHub will auto-rebase the base of this PR to main and the diff will narrow to just the LogDbCommand changes.

## Test plan
- [x] Release build clean across all 4 source TFMs — 0 warnings, 0 errors
- [x] All 72 tests pass on net462, net47, net471, net472, net48, net481, net6.0, net7.0, net8.0, net9.0, net10.0 (30 from #4 + 42 new)
- [x] net5.0 exits clean (xunit discoverer no-op, same as #4)
- [x] Coverage: null guards on every overload, level filtering, parameter capture (full metadata), redaction across name/prefix/case variants, helper edge cases (empty/null inputs)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)