### PR TITLE
Add LogDbParameter extension methods

### DIFF
--- a/src/Wolfgang.Extensions.Logging.Data/DbParameterLoggerExtensions.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/DbParameterLoggerExtensions.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Data.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data;
+
+/// <summary>
+/// Extension methods on <see cref="ILogger"/> for logging individual <see cref="DbParameter"/> instances.
+/// </summary>
+/// <remarks>
+/// Each call emits a single structured log entry containing the parameter's metadata
+/// (<c>ParameterName</c>, <c>DbType</c>, <c>Direction</c>, <c>Size</c>, <c>Precision</c>,
+/// <c>Scale</c>, <c>IsNullable</c>) and either its <c>Value</c> or the literal
+/// string <c>[REDACTED]</c> when the caller passes <c>redactValue: true</c>.
+/// </remarks>
+public static class DbParameterLoggerExtensions
+{
+    private const string MessageTemplate =
+        "DbParameter Name={ParameterName} DbType={DbType} Direction={Direction} Size={Size} Precision={Precision} Scale={Scale} IsNullable={IsNullable} Value={Value}";
+
+    private const string RedactedValue = "[REDACTED]";
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameter"/> at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameter">The parameter to log.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameter"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameter(this ILogger logger, DbParameter parameter)
+    {
+        LogDbParameter(logger, parameter, redactValue: false, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameter"/> at the specified
+    /// <paramref name="level"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameter">The parameter to log.</param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameter"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameter(this ILogger logger, DbParameter parameter, LogLevel level)
+    {
+        LogDbParameter(logger, parameter, redactValue: false, level);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameter"/> at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information, optionally redacting the value.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameter">The parameter to log.</param>
+    /// <param name="redactValue">
+    /// When <see langword="true"/>, the parameter value is replaced with the literal string
+    /// <c>[REDACTED]</c>. All other metadata is preserved.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameter"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameter(this ILogger logger, DbParameter parameter, bool redactValue)
+    {
+        LogDbParameter(logger, parameter, redactValue, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameter"/> at the specified
+    /// <paramref name="level"/>, optionally redacting the value.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameter">The parameter to log.</param>
+    /// <param name="redactValue">
+    /// When <see langword="true"/>, the parameter value is replaced with the literal string
+    /// <c>[REDACTED]</c>. All other metadata is preserved.
+    /// </param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameter"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameter
+    (
+        this ILogger logger,
+        DbParameter parameter,
+        bool redactValue,
+        LogLevel level
+    )
+    {
+        if (logger is null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (parameter is null)
+        {
+            throw new ArgumentNullException(nameof(parameter));
+        }
+
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        var value = redactValue ? (object?)RedactedValue : parameter.Value;
+
+        logger.Log
+        (
+            level,
+            MessageTemplate,
+            parameter.ParameterName,
+            parameter.DbType,
+            parameter.Direction,
+            parameter.Size,
+            parameter.Precision,
+            parameter.Scale,
+            parameter.IsNullable,
+            value
+        );
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbParameterLoggerExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbParameterLoggerExtensionsTests.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Data;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit;
+
+public class DbParameterLoggerExtensionsTests
+{
+    private static FakeDbParameter CreateParameter()
+    {
+        return new FakeDbParameter
+        {
+            ParameterName = "@id",
+            DbType = DbType.Int32,
+            Direction = ParameterDirection.Input,
+            Size = 4,
+            Precision = 10,
+            Scale = 0,
+            IsNullable = false,
+            Value = 42
+        };
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameter = CreateParameter();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(parameter));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameter = CreateParameter();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(parameter, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameter = CreateParameter();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(parameter, redactValue: true));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_and_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameter = CreateParameter();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(parameter, redactValue: true, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_when_parameter_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(parameter: null!));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_level_when_parameter_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(null!, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_when_log_level_is_disabled_writes_nothing()
+    {
+        var logger = new RecordingLogger { MinimumLevel = LogLevel.Warning };
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, LogLevel.Information);
+
+        Assert.Empty(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_default_overload_logs_at_information()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+    }
+
+
+
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public void LogDbParameter_logs_at_specified_level(LogLevel level)
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, level);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(level, entry.Level);
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_includes_all_metadata_fields()
+    {
+        var logger = new RecordingLogger();
+        var parameter = new FakeDbParameter
+        {
+            ParameterName = "@total",
+            DbType = DbType.Decimal,
+            Direction = ParameterDirection.InputOutput,
+            Size = 9,
+            Precision = 18,
+            Scale = 4,
+            IsNullable = true,
+            Value = 12.34m
+        };
+
+        logger.LogDbParameter(parameter);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal("@total", entry.GetValue("ParameterName"));
+        Assert.Equal(DbType.Decimal, entry.GetValue("DbType"));
+        Assert.Equal(ParameterDirection.InputOutput, entry.GetValue("Direction"));
+        Assert.Equal(9, entry.GetValue("Size"));
+        Assert.Equal((byte)18, entry.GetValue("Precision"));
+        Assert.Equal((byte)4, entry.GetValue("Scale"));
+        Assert.Equal(true, entry.GetValue("IsNullable"));
+        Assert.Equal(12.34m, entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_default_overload_does_not_redact_value()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(42, entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_level_only_does_not_redact_value()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, LogLevel.Warning);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(42, entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_true_replaces_value_with_redacted_marker()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, redactValue: true);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal("[REDACTED]", entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_false_keeps_value()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, redactValue: false);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(42, entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_true_keeps_metadata()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, redactValue: true);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal("@id", entry.GetValue("ParameterName"));
+        Assert.Equal(DbType.Int32, entry.GetValue("DbType"));
+        Assert.Equal(ParameterDirection.Input, entry.GetValue("Direction"));
+        Assert.Equal(4, entry.GetValue("Size"));
+        Assert.Equal((byte)10, entry.GetValue("Precision"));
+        Assert.Equal((byte)0, entry.GetValue("Scale"));
+        Assert.Equal(false, entry.GetValue("IsNullable"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_and_level_uses_both()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, redactValue: true, LogLevel.Warning);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal("[REDACTED]", entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_null_value_logs_null()
+    {
+        var logger = new RecordingLogger();
+        var parameter = new FakeDbParameter
+        {
+            ParameterName = "@nullable",
+            Value = null
+        };
+
+        logger.LogDbParameter(parameter);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Null(entry.GetValue("Value"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `LogDbParameter` (four overloads) — emits one structured entry per call with the parameter's full metadata.
- The `redactValue` flag (defaulting to `false`) replaces the value with the literal `[REDACTED]` while preserving every other field. This mirrors the per-parameter redaction model from `LogDbCommand` but exposes it as a simple bool since there's only one parameter to consider.

## Stacked on Extensions-Logging-Data#6
Base is `feature/log-db-command`, not `main`. Diff currently shows commits from #4 and #6 too; once those merge upstream GitHub will rebase the base and the diff narrows.

## Test plan
- [x] Release build clean across all 4 source TFMs — 0 warnings, 0 errors
- [x] All 94 tests pass on 11 TFMs (72 from prior PRs + 22 new)
- [x] Coverage: null guards on every overload, level filtering, full metadata capture, redact-true / redact-false / default behavior, null Value
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)