### PR TITLE
Add LogDbParameterCollection extension methods

### DIFF
--- a/Extensions-Logging-Data.slnx
+++ b/Extensions-Logging-Data.slnx
@@ -41,7 +41,9 @@
     <File Path="scripts/setup.ps1" />
   </Folder>
   <Folder Name="/benchmarks/" />
-  <Folder Name="/examples/" />
+  <Folder Name="/examples/">
+    <Project Path="examples/Wolfgang.Extensions.Logging.Data.Example/Wolfgang.Extensions.Logging.Data.Example.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj" />
   </Folder>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Wolfgang.Extensions-Logging-Data
+# Wolfgang.Extensions.Logging.Data
 
-Exntension methods to ILogger and ILogger<T> for logging DbConnection, DbCommand, and other System.Data related data
+Extension methods for `ILogger` and `ILogger<T>` that log `DbConnection`, `DbCommand`, `DbParameter`, `DbParameterCollection`, and raw SQL command text from `System.Data.Common` &mdash; with built-in secret redaction (passwords in connection strings, configurable parameter values).
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
@@ -11,7 +11,7 @@ Exntension methods to ILogger and ILogger<T> for logging DbConnection, DbCommand
 ## 📦 Installation
 
 ```bash
-dotnet add package Wolfgang.Extensions-Logging-Data
+dotnet add package Wolfgang.Extensions.Logging.Data
 ```
 
 **NuGet Package:** Coming soon to NuGet.org
@@ -35,26 +35,58 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 
 ## 🚀 Quick Start
 
-{{QUICK_START_EXAMPLE}}
+```csharp
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data;
+
+using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+ILogger logger = loggerFactory.CreateLogger("Demo");
+
+await using var connection = new SqliteConnection("Data Source=:memory:;User=alice;Password=topsecret");
+await connection.OpenAsync();
+
+// Logs ConnectionType, Database, DataSource, ServerVersion, State,
+// ConnectionTimeout, and the connection string with Password removed.
+logger.LogDbConnection(connection);
+
+await using var command = connection.CreateCommand();
+command.CommandText = "INSERT INTO Users (Email, PasswordHash) VALUES (@email, @password)";
+command.Parameters.AddWithValue("@email", "alice@example.com");
+command.Parameters.AddWithValue("@password", "hashed-secret");
+
+// Logs the command and every parameter; the @password value is replaced
+// with "[REDACTED]" while name, DbType, direction, etc. are preserved.
+logger.LogDbCommand(command, excludedParameterNames: new[] { "@password" });
+```
+
+A full runnable example lives in [examples/Wolfgang.Extensions.Logging.Data.Example](examples/Wolfgang.Extensions.Logging.Data.Example).
 
 ---
 
 ## ✨ Features
 
-{{FEATURES_TABLE}}
+| Method | What it captures | Redaction |
+|---|---|---|
+| `LogDbConnection` | `ConnectionType`, `Database`, `DataSource`, `ServerVersion` (when open), `State`, `ConnectionTimeout`, `ConnectionString` | `Password` and `Pwd` keys are removed from the connection string (case-insensitive). User name (`User ID`, `UID`, etc.) is preserved. |
+| `LogDbCommand` | `CommandType`, `CommandText`, `CommandTimeout`, snapshot of every parameter (name, `DbType`, direction, size, precision, scale, nullability, value) | Pass `excludedParameterNames`; values for matching parameters become `"[REDACTED]"`. |
+| `LogDbParameter` | A single parameter's full metadata + value | Pass `redactValue: true` to replace the value with `"[REDACTED]"`. |
+| `LogDbParameterCollection` | `Count` and a snapshot of every parameter | Pass `excludedParameterNames`; values for matching parameters become `"[REDACTED]"`. |
+| `LogCommandText` | Raw SQL `CommandText` and an optional `IReadOnlyDictionary<string, object?>` of parameter values | Pass `excludedParameterNames`; values for matching keys become `"[REDACTED]"`. |
 
-**Examples:**
-{{FEATURE_EXAMPLES}}
+**Parameter name matching for `excludedParameterNames`** is **case-insensitive** and **tolerant of provider prefixes** &mdash; `@password`, `:password`, `?password`, and `password` all match a parameter named `@password`. Each method emits **one structured log entry per call** so sinks like Serilog, Seq, or Application Insights can index/filter on the named template fields.
 
 ---
 
 ## 🎯 Target Frameworks
 
+The library targets a broad range of TFMs so it can be consumed from .NET Framework, .NET Standard, and modern .NET projects alike.
+
 | Framework | Versions |
 |-----------|----------|
-| .NET Framework | .NET 4.6.2, .NET 4.7.0, .NET 4.7.1, .NET 4.7.2, .NET 4.8, .NET 4.8.1 |
-| .NET Core | .NET Core 3.1 |
-| .NET | .NET 5.0, .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0, .NET 10.0 |
+| .NET Framework | 4.6.2 and later |
+| .NET Standard | 2.0, 2.1 |
+| .NET | 10.0 |
 
 ---
 
@@ -177,5 +209,6 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 ## 🙏 Acknowledgments
 
-{{ACKNOWLEDGMENTS}}
+- Built on top of [Microsoft.Extensions.Logging.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/) and `System.Data.Common`.
+- Maintained by [Chris Wolfgang](https://github.com/Chris-Wolfgang).
 

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -1,53 +1,116 @@
 # Getting Started
 
-This guide will help you quickly get up and running with Wolfgang.Extensions-Logging-Data.
+This guide walks through installing `Wolfgang.Extensions.Logging.Data`, making your first call, and understanding the redaction model.
 
 ## Prerequisites
 
-<!-- List any prerequisites needed. For example:
-- .NET 8.0 or later
-- Visual Studio 2022 or Visual Studio Code
--->
+- An `ILogger` from `Microsoft.Extensions.Logging.Abstractions` (any provider works &mdash; Serilog, console, Seq, Application Insights, in-memory, etc.).
+- A target framework of .NET Framework 4.6.2 or later, .NET Standard 2.0 or 2.1, or .NET 10.0 or later.
 
 ## Installation
 
 ### Via NuGet Package Manager
 
 ```bash
-dotnet add package Wolfgang.Extensions-Logging-Data
+dotnet add package Wolfgang.Extensions.Logging.Data
 ```
 
 ### Via Package Manager Console
 
 ```powershell
-Install-Package Wolfgang.Extensions-Logging-Data
+Install-Package Wolfgang.Extensions.Logging.Data
 ```
 
-## Quick Start
-
-<!-- Add a quick start example. For example: -->
+## Your first call
 
 ```csharp
-// Add your quick start code example here
-// This should show the simplest way to use your library
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data;
 
-using Wolfgang.Extensions-Logging-Data;
+using var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+ILogger logger = loggerFactory.CreateLogger("Demo");
 
-// Example usage
+await using var connection = new SqliteConnection("Data Source=:memory:;Password=topsecret");
+await connection.OpenAsync();
+
+logger.LogDbConnection(connection);
 ```
 
-## Next Steps
+The output (with the default console formatter) looks something like:
 
-- Explore the [API Reference](../api/index.md) for detailed documentation
-- Read the [Introduction](introduction.md) to learn more about Wolfgang.Extensions-Logging-Data
-- Check out example projects in the [GitHub repository](https://github.com/Chris-Wolfgang/Extensions-Logging-Data)
+```
+info: Demo[0]
+      DbConnection Microsoft.Data.Sqlite.SqliteConnection Database=main DataSource=:memory: ServerVersion=3.42.0 State=Open ConnectionTimeout=30 ConnectionString=Data Source=:memory:
+```
 
-## Common Issues
+Note that the password is gone but everything else &mdash; including the username, if present &mdash; is preserved.
 
-<!-- Add common issues and their solutions here -->
+## The five extension methods
 
-## Additional Resources
+### `LogDbConnection`
 
-- [GitHub Repository](https://github.com/Chris-Wolfgang/Extensions-Logging-Data)
-- [Contributing Guidelines](https://github.com/Chris-Wolfgang/Extensions-Logging-Data/blob/main/CONTRIBUTING.md)
-- [Report an Issue](https://github.com/Chris-Wolfgang/Extensions-Logging-Data/issues)
+```csharp
+logger.LogDbConnection(connection);
+logger.LogDbConnection(connection, LogLevel.Debug);
+```
+
+Logs `ConnectionType`, `Database`, `DataSource`, `ServerVersion`, `State`, `ConnectionTimeout`, and the redacted `ConnectionString`. `ServerVersion` is read only when the connection is open; if the provider throws `InvalidOperationException` reading it, the field is logged as `null` rather than bubbling.
+
+### `LogDbCommand`
+
+```csharp
+logger.LogDbCommand(command);
+logger.LogDbCommand(command, excludedParameterNames: new[] { "@password" });
+logger.LogDbCommand(command, excluded, LogLevel.Debug);
+```
+
+Logs `CommandType`, `CommandText`, `CommandTimeout`, and a snapshot of every parameter (name, `DbType`, direction, size, precision, scale, nullability, value). Names in `excludedParameterNames` cause the matching parameter's value to be replaced with `"[REDACTED]"`; all other metadata is preserved.
+
+### `LogDbParameter`
+
+```csharp
+logger.LogDbParameter(parameter);
+logger.LogDbParameter(parameter, redactValue: true);
+```
+
+Logs a single parameter's full metadata + value. The `redactValue` flag (defaulting to `false`) replaces the value with `"[REDACTED]"`.
+
+### `LogDbParameterCollection`
+
+```csharp
+logger.LogDbParameterCollection(command.Parameters);
+logger.LogDbParameterCollection(command.Parameters, new[] { "@password" });
+```
+
+Logs `Count` and a snapshot of every parameter. Same redaction rules as `LogDbCommand`.
+
+### `LogCommandText`
+
+For code paths that have raw SQL and a parameter dictionary but no `DbCommand`:
+
+```csharp
+logger.LogCommandText("SELECT * FROM Users WHERE Email=@email");
+
+logger.LogCommandText(
+    "UPDATE Users SET PasswordHash=@password WHERE Email=@email",
+    new Dictionary<string, object?>
+    {
+        ["@email"] = "alice@example.com",
+        ["@password"] = "new-hash"
+    },
+    excludedParameterNames: new[] { "@password" });
+```
+
+## The redaction model
+
+- **Connection-string passwords are always redacted.** `LogDbConnection` removes `Password` and `Pwd` keys (case-insensitive) using `DbConnectionStringBuilder`.
+- **Parameter-value redaction is opt-in.** Methods that touch parameters take an `excludedParameterNames` list; only the values for matching names are replaced. Name, `DbType`, direction, etc. are always preserved so logs remain useful.
+- **Name matching is case-insensitive and prefix-tolerant.** `@password`, `:password`, `?password`, and `password` are all equivalent for matching purposes.
+- **The marker is the literal string `"[REDACTED]"`.**
+
+## Where to next
+
+- Browse the [API Reference](xref:Wolfgang.Extensions.Logging.Data) for the full method signatures and XML docs.
+- Look at the [example app](https://github.com/Chris-Wolfgang/Extensions-Logging-Data/tree/main/examples/Wolfgang.Extensions.Logging.Data.Example) for a working end-to-end demo against an in-memory SQLite database.
+- File issues or feature requests at [GitHub Issues](https://github.com/Chris-Wolfgang/Extensions-Logging-Data/issues).

--- a/docfx_project/docs/introduction.md
+++ b/docfx_project/docs/introduction.md
@@ -1,26 +1,38 @@
 # Introduction
 
-Welcome to Wolfgang.Extensions-Logging-Data!
+`Wolfgang.Extensions.Logging.Data` adds `ILogger` extension methods that produce a single structured log entry for the most common ADO.NET objects. It is designed for diagnostic logging of database calls in production code where connection strings and parameter values may contain secrets.
 
-## Overview
+## What it does
 
-Exntension methods to ILogger and ILogger<T> for logging DbConnection, DbCommand, and other System.Data related data
+| Method | Purpose |
+|---|---|
+| `LogDbConnection` | Logs a `DbConnection`'s state, server, database, and connection string (with password keys removed). |
+| `LogDbCommand` | Logs a `DbCommand`'s text, type, timeout, and a snapshot of every parameter. |
+| `LogDbParameter` | Logs a single `DbParameter`'s metadata and (optionally redacted) value. |
+| `LogDbParameterCollection` | Logs the count and a snapshot of every parameter in a collection. |
+| `LogCommandText` | Logs raw SQL plus an optional `IReadOnlyDictionary<string, object?>` of parameter values, for callers without a `DbCommand` in hand. |
 
-<!-- Add your project overview here -->
+## Design principles
 
-## Key Features
+- **One entry per call.** Each method emits exactly one structured log entry with named template fields, so sinks like Serilog, Seq, or Application Insights can index and filter on them.
+- **Secure by default for connection strings.** `LogDbConnection` parses the connection string via `DbConnectionStringBuilder` and removes the `Password` and `Pwd` keys (case-insensitive). Username keys (`User ID`, `UID`, etc.) are preserved.
+- **Opt-in redaction for parameters.** Methods that take parameters accept an `excludedParameterNames` list; values for matching parameters become the literal string `"[REDACTED]"` while name, `DbType`, direction, size, precision, scale, and nullability are preserved.
+- **Tolerant matching.** Excluded-name matching is case-insensitive and ignores provider prefixes &mdash; `@password`, `:password`, `?password`, and `password` are all equivalent.
+- **No I/O.** The methods are pure logging calls; they don't open connections, execute commands, or touch the database.
 
-<!-- List the main features of your project. For example:
-- Feature 1: Description
-- Feature 2: Description
-- Feature 3: Description
--->
+## When to use it
+
+- Diagnostic logging of database operations in services, jobs, or background workers.
+- Auditing what a command actually sent to the database, including its parameters, without leaking credentials or secrets.
+- Reproducing customer-reported bugs by capturing the exact `DbCommand` shape that was executed.
+
+## When *not* to use it
+
+- High-throughput hot paths where every microsecond matters &mdash; consider a `LoggerMessage` source-generator approach for those (a future enhancement is tracked in [issue #3](https://github.com/Chris-Wolfgang/Extensions-Logging-Data/issues/3)).
+- Replacing your provider's existing diagnostic source / `EventCounter` instrumentation. This library complements that, it doesn't replace it.
 
 ## Getting Help
 
-If you need help with Wolfgang.Extensions-Logging-Data, please:
-
-- Check the [Getting Started](getting-started.md) guide
-- Review the [API Reference](../api/index.md)
-- Visit the [GitHub repository](https://github.com/Chris-Wolfgang/Extensions-Logging-Data)
-- Open an issue on [GitHub Issues](https://github.com/Chris-Wolfgang/Extensions-Logging-Data/issues)
+- Read the [Getting Started](getting-started.md) guide
+- Browse the [API Reference](xref:Wolfgang.Extensions.Logging.Data)
+- File issues at [GitHub Issues](https://github.com/Chris-Wolfgang/Extensions-Logging-Data/issues)

--- a/docfx_project/index.md
+++ b/docfx_project/index.md
@@ -2,33 +2,42 @@
 _layout: landing
 ---
 
-# Wolfgang.Extensions-Logging-Data Documentation
+# Wolfgang.Extensions.Logging.Data
 
-Welcome to the Wolfgang.Extensions-Logging-Data documentation. This site contains comprehensive guides, API reference, and examples to help you get started.
+Extension methods for `ILogger` and `ILogger<T>` that log `DbConnection`, `DbCommand`, `DbParameter`, `DbParameterCollection`, and raw SQL command text from `System.Data.Common` &mdash; with built-in secret redaction.
 
 ## Quick Links
 
-- [Getting Started](docs/getting-started.md) - Learn the basics
-- [API Reference](xref:Wolfgang.Extensions-Logging-Data) - Complete API documentation
-- [GitHub Repository](https://github.com/Chris-Wolfgang/Extensions-Logging-Data) - View source code
-
-## About Wolfgang.Extensions-Logging-Data
-
-Exntension methods to ILogger and ILogger<T> for logging DbConnection, DbCommand, and other System.Data related data
+- [Introduction](docs/introduction.md) &mdash; what the library does and why
+- [Getting Started](docs/getting-started.md) &mdash; install, first call, and the redaction model
+- [API Reference](xref:Wolfgang.Extensions.Logging.Data) &mdash; full type and method documentation
+- [GitHub Repository](https://github.com/Chris-Wolfgang/Extensions-Logging-Data)
 
 ## Installation
 
 ```bash
-dotnet add package Wolfgang.Extensions-Logging-Data
+dotnet add package Wolfgang.Extensions.Logging.Data
 ```
+
+## At a glance
+
+```csharp
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data;
+
+logger.LogDbConnection(connection);
+logger.LogDbCommand(command, excludedParameterNames: new[] { "@password" });
+```
+
+Each call emits a single structured log entry with named template fields (`ConnectionType`, `Database`, `CommandText`, `Parameters`, &hellip;) so sinks like Serilog, Seq, or Application Insights can index and filter on them. Connection-string passwords are removed automatically; parameter values are redacted by name on an opt-in basis.
 
 ## Documentation Sections
 
 ### 📖 [Documentation](docs/getting-started.md)
-Step-by-step guides and tutorials to help you use Wolfgang.Extensions-Logging-Data effectively.
+Step-by-step guides covering installation, the five extension methods, and the redaction model.
 
-### 📚 [API Reference](xref:Wolfgang.Extensions-Logging-Data)
-Complete API documentation automatically generated from source code XML comments.
+### 📚 [API Reference](xref:Wolfgang.Extensions.Logging.Data)
+Complete API documentation generated from XML doc comments in the source.
 
 ## Additional Resources
 
@@ -39,4 +48,3 @@ Complete API documentation automatically generated from source code XML comments
 ---
 
 *Documentation built with [DocFX](https://dotnet.github.io/docfx/)*
-

--- a/examples/Wolfgang.Extensions.Logging.Data.Example/Program.cs
+++ b/examples/Wolfgang.Extensions.Logging.Data.Example/Program.cs
@@ -1,0 +1,69 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data;
+
+using var loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder
+        .SetMinimumLevel(LogLevel.Information)
+        .AddSimpleConsole(options =>
+        {
+            options.SingleLine = true;
+            options.IncludeScopes = false;
+        });
+});
+
+ILogger logger = loggerFactory.CreateLogger("Demo");
+
+// 1. LogDbConnection — set up a connection string that includes a Password.
+//    Microsoft.Data.Sqlite with the e_sqlite3 bundle rejects Password at Open(),
+//    so we log the closed connection here. That still demonstrates the redaction:
+//    Password is removed from the logged ConnectionString while Data Source remains.
+await using var connectionWithSecret = new SqliteConnection("Data Source=demo.db;Password=topsecret");
+logger.LogDbConnection(connectionWithSecret);
+
+// Now open a clean in-memory connection for the actual SQL operations and log it
+// again — this time you can see ServerVersion, State=Open, etc.
+await using var connection = new SqliteConnection("Data Source=:memory:");
+await connection.OpenAsync();
+logger.LogDbConnection(connection);
+
+// 2. Set up a Users table and a parameterized INSERT.
+await using (var create = connection.CreateCommand())
+{
+    create.CommandText = "CREATE TABLE Users (Id INTEGER PRIMARY KEY, Email TEXT, PasswordHash TEXT)";
+    await create.ExecuteNonQueryAsync();
+}
+
+await using var insert = connection.CreateCommand();
+insert.CommandText = "INSERT INTO Users (Email, PasswordHash) VALUES (@email, @password)";
+var emailParam = insert.CreateParameter();
+emailParam.ParameterName = "@email";
+emailParam.Value = "alice@example.com";
+insert.Parameters.Add(emailParam);
+
+var passwordParam = insert.CreateParameter();
+passwordParam.ParameterName = "@password";
+passwordParam.Value = "hashed-secret-value";
+insert.Parameters.Add(passwordParam);
+
+// 3. LogDbCommand — every parameter is captured; only the @password value is redacted.
+logger.LogDbCommand(insert, excludedParameterNames: new[] { "@password" });
+await insert.ExecuteNonQueryAsync();
+
+// 4. LogDbParameter — single-parameter view with explicit redaction toggle.
+logger.LogDbParameter(passwordParam, redactValue: true);
+
+// 5. LogDbParameterCollection — the whole collection in one entry, with the same
+//    case-insensitive prefix-tolerant matching ("password" matches "@password").
+logger.LogDbParameterCollection(insert.Parameters, excludedParameterNames: new[] { "password" });
+
+// 6. LogCommandText — for code paths that have raw SQL + values but no DbCommand.
+logger.LogCommandText(
+    "UPDATE Users SET PasswordHash = @password WHERE Email = @email",
+    new Dictionary<string, object?>
+    {
+        ["@email"] = "alice@example.com",
+        ["@password"] = "new-hashed-secret"
+    },
+    excludedParameterNames: new[] { "@password" });

--- a/examples/Wolfgang.Extensions.Logging.Data.Example/Wolfgang.Extensions.Logging.Data.Example.csproj
+++ b/examples/Wolfgang.Extensions.Logging.Data.Example/Wolfgang.Extensions.Logging.Data.Example.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <!-- ConfigureAwait is library-code guidance; this console demo runs without a sync context. -->
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.Logging.Data\Wolfgang.Extensions.Logging.Data.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Wolfgang.Extensions.Logging.Data/CommandTextLoggerExtensions.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/CommandTextLoggerExtensions.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data;
+
+/// <summary>
+/// Extension methods on <see cref="ILogger"/> for logging raw SQL command text and an optional
+/// dictionary of parameter values, for callers that don't have a <see cref="System.Data.Common.DbCommand"/>
+/// in hand.
+/// </summary>
+/// <remarks>
+/// Each call emits a single structured log entry. Parameter values can be selectively redacted by
+/// passing a list of parameter names; matching is case-insensitive and tolerant of provider prefixes
+/// (<c>@name</c>, <c>:name</c>, <c>?name</c>, and <c>name</c> are all equivalent). Redacted values
+/// are replaced with the literal string <c>[REDACTED]</c>.
+/// </remarks>
+public static class CommandTextLoggerExtensions
+{
+    private const string TextOnlyTemplate = "CommandText {CommandText}";
+
+    private const string TextAndParametersTemplate = "CommandText {CommandText} Parameters={Parameters}";
+
+    private const string RedactedValue = "[REDACTED]";
+
+
+
+    /// <summary>
+    /// Logs <paramref name="commandText"/> as a single structured entry at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="commandText">The SQL command text to log.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="commandText"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogCommandText(this ILogger logger, string commandText)
+    {
+        LogCommandText(logger, commandText, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs <paramref name="commandText"/> as a single structured entry at the specified
+    /// <paramref name="level"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="commandText">The SQL command text to log.</param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="commandText"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogCommandText(this ILogger logger, string commandText, LogLevel level)
+    {
+        if (logger is null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (commandText is null)
+        {
+            throw new ArgumentNullException(nameof(commandText));
+        }
+
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        logger.Log(level, TextOnlyTemplate, commandText);
+    }
+
+
+
+    /// <summary>
+    /// Logs <paramref name="commandText"/> together with <paramref name="parameters"/> as a single
+    /// structured entry at <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="commandText">The SQL command text to log.</param>
+    /// <param name="parameters">The parameter name/value pairs to log alongside the command text.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when any argument is <see langword="null"/>.
+    /// </exception>
+    public static void LogCommandText
+    (
+        this ILogger logger,
+        string commandText,
+        IReadOnlyDictionary<string, object?> parameters
+    )
+    {
+        LogCommandText(logger, commandText, parameters, excludedParameterNames: null, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs <paramref name="commandText"/> together with <paramref name="parameters"/> as a single
+    /// structured entry at the specified <paramref name="level"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="commandText">The SQL command text to log.</param>
+    /// <param name="parameters">The parameter name/value pairs to log alongside the command text.</param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when any argument is <see langword="null"/>.
+    /// </exception>
+    public static void LogCommandText
+    (
+        this ILogger logger,
+        string commandText,
+        IReadOnlyDictionary<string, object?> parameters,
+        LogLevel level
+    )
+    {
+        LogCommandText(logger, commandText, parameters, excludedParameterNames: null, level);
+    }
+
+
+
+    /// <summary>
+    /// Logs <paramref name="commandText"/> together with <paramref name="parameters"/> as a single
+    /// structured entry at <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information, redacting
+    /// the values of any parameters whose names appear in <paramref name="excludedParameterNames"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="commandText">The SQL command text to log.</param>
+    /// <param name="parameters">The parameter name/value pairs to log alongside the command text.</param>
+    /// <param name="excludedParameterNames">
+    /// Parameter names whose values should be replaced with the literal string <c>[REDACTED]</c>.
+    /// Matching is case-insensitive and ignores provider prefixes (<c>@</c>, <c>:</c>, <c>?</c>).
+    /// May be <see langword="null"/> for no redaction.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/>, <paramref name="commandText"/>, or
+    /// <paramref name="parameters"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogCommandText
+    (
+        this ILogger logger,
+        string commandText,
+        IReadOnlyDictionary<string, object?> parameters,
+        IEnumerable<string>? excludedParameterNames
+    )
+    {
+        LogCommandText(logger, commandText, parameters, excludedParameterNames, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs <paramref name="commandText"/> together with <paramref name="parameters"/> as a single
+    /// structured entry at the specified <paramref name="level"/>, redacting the values of any
+    /// parameters whose names appear in <paramref name="excludedParameterNames"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="commandText">The SQL command text to log.</param>
+    /// <param name="parameters">The parameter name/value pairs to log alongside the command text.</param>
+    /// <param name="excludedParameterNames">
+    /// Parameter names whose values should be replaced with the literal string <c>[REDACTED]</c>.
+    /// Matching is case-insensitive and ignores provider prefixes (<c>@</c>, <c>:</c>, <c>?</c>).
+    /// May be <see langword="null"/> for no redaction.
+    /// </param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/>, <paramref name="commandText"/>, or
+    /// <paramref name="parameters"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogCommandText
+    (
+        this ILogger logger,
+        string commandText,
+        IReadOnlyDictionary<string, object?> parameters,
+        IEnumerable<string>? excludedParameterNames,
+        LogLevel level
+    )
+    {
+        if (logger is null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (commandText is null)
+        {
+            throw new ArgumentNullException(nameof(commandText));
+        }
+
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        var loggedParameters = ApplyRedaction(parameters, excludedParameterNames);
+
+        logger.Log(level, TextAndParametersTemplate, commandText, loggedParameters);
+    }
+
+
+
+    internal static IReadOnlyDictionary<string, object?> ApplyRedaction
+    (
+        IReadOnlyDictionary<string, object?> parameters,
+        IEnumerable<string>? excludedParameterNames
+    )
+    {
+        var excluded = DbCommandLoggerExtensions.NormalizeExcluded(excludedParameterNames);
+        if (excluded.Count == 0 || parameters.Count == 0)
+        {
+            return parameters;
+        }
+
+        var result = new Dictionary<string, object?>(parameters.Count);
+        foreach (var kvp in parameters)
+        {
+            var redact = DbCommandLoggerExtensions.ShouldRedact(kvp.Key, excluded);
+            result[kvp.Key] = redact ? RedactedValue : kvp.Value;
+        }
+        return result;
+    }
+}

--- a/src/Wolfgang.Extensions.Logging.Data/DbParameterCollectionLoggerExtensions.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/DbParameterCollectionLoggerExtensions.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data;
+
+/// <summary>
+/// Extension methods on <see cref="ILogger"/> for logging <see cref="DbParameterCollection"/> instances.
+/// </summary>
+/// <remarks>
+/// Each call emits a single structured log entry containing the count and a snapshot of every
+/// parameter in the collection. Parameter values can be selectively redacted by passing a list of
+/// parameter names; matching is case-insensitive and tolerant of provider prefixes
+/// (<c>@name</c>, <c>:name</c>, <c>?name</c>, and <c>name</c> are all equivalent).
+/// </remarks>
+public static class DbParameterCollectionLoggerExtensions
+{
+    private const string MessageTemplate =
+        "DbParameterCollection Count={Count} Parameters={Parameters}";
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameters"/> at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameters">The parameter collection to log.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameters"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameterCollection(this ILogger logger, DbParameterCollection parameters)
+    {
+        LogDbParameterCollection(logger, parameters, excludedParameterNames: null, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameters"/> at the specified
+    /// <paramref name="level"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameters">The parameter collection to log.</param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameters"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameterCollection(this ILogger logger, DbParameterCollection parameters, LogLevel level)
+    {
+        LogDbParameterCollection(logger, parameters, excludedParameterNames: null, level);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameters"/> at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information, redacting the values of any
+    /// parameters whose names appear in <paramref name="excludedParameterNames"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameters">The parameter collection to log.</param>
+    /// <param name="excludedParameterNames">
+    /// Parameter names whose values should be replaced with the literal string <c>[REDACTED]</c>.
+    /// Matching is case-insensitive and ignores provider prefixes (<c>@</c>, <c>:</c>, <c>?</c>).
+    /// May be <see langword="null"/> for no redaction.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameters"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameterCollection
+    (
+        this ILogger logger,
+        DbParameterCollection parameters,
+        IEnumerable<string>? excludedParameterNames
+    )
+    {
+        LogDbParameterCollection(logger, parameters, excludedParameterNames, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameters"/> at the specified
+    /// <paramref name="level"/>, redacting the values of any parameters whose names appear in
+    /// <paramref name="excludedParameterNames"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameters">The parameter collection to log.</param>
+    /// <param name="excludedParameterNames">
+    /// Parameter names whose values should be replaced with the literal string <c>[REDACTED]</c>.
+    /// Matching is case-insensitive and ignores provider prefixes (<c>@</c>, <c>:</c>, <c>?</c>).
+    /// May be <see langword="null"/> for no redaction.
+    /// </param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameters"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameterCollection
+    (
+        this ILogger logger,
+        DbParameterCollection parameters,
+        IEnumerable<string>? excludedParameterNames,
+        LogLevel level
+    )
+    {
+        if (logger is null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        var snapshots = DbCommandLoggerExtensions.SnapshotParameters(parameters, excludedParameterNames);
+
+        logger.Log
+        (
+            level,
+            MessageTemplate,
+            parameters.Count,
+            snapshots
+        );
+    }
+}

--- a/src/Wolfgang.Extensions.Logging.Data/DbParameterLoggerExtensions.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/DbParameterLoggerExtensions.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Data.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data;
+
+/// <summary>
+/// Extension methods on <see cref="ILogger"/> for logging individual <see cref="DbParameter"/> instances.
+/// </summary>
+/// <remarks>
+/// Each call emits a single structured log entry containing the parameter's metadata
+/// (<c>ParameterName</c>, <c>DbType</c>, <c>Direction</c>, <c>Size</c>, <c>Precision</c>,
+/// <c>Scale</c>, <c>IsNullable</c>) and either its <c>Value</c> or the literal
+/// string <c>[REDACTED]</c> when the caller passes <c>redactValue: true</c>.
+/// </remarks>
+public static class DbParameterLoggerExtensions
+{
+    private const string MessageTemplate =
+        "DbParameter Name={ParameterName} DbType={DbType} Direction={Direction} Size={Size} Precision={Precision} Scale={Scale} IsNullable={IsNullable} Value={Value}";
+
+    private const string RedactedValue = "[REDACTED]";
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameter"/> at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameter">The parameter to log.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameter"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameter(this ILogger logger, DbParameter parameter)
+    {
+        LogDbParameter(logger, parameter, redactValue: false, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameter"/> at the specified
+    /// <paramref name="level"/>.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameter">The parameter to log.</param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameter"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameter(this ILogger logger, DbParameter parameter, LogLevel level)
+    {
+        LogDbParameter(logger, parameter, redactValue: false, level);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameter"/> at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel"/>.Information, optionally redacting the value.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameter">The parameter to log.</param>
+    /// <param name="redactValue">
+    /// When <see langword="true"/>, the parameter value is replaced with the literal string
+    /// <c>[REDACTED]</c>. All other metadata is preserved.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameter"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameter(this ILogger logger, DbParameter parameter, bool redactValue)
+    {
+        LogDbParameter(logger, parameter, redactValue, LogLevel.Information);
+    }
+
+
+
+    /// <summary>
+    /// Logs a single structured entry describing the <paramref name="parameter"/> at the specified
+    /// <paramref name="level"/>, optionally redacting the value.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="parameter">The parameter to log.</param>
+    /// <param name="redactValue">
+    /// When <see langword="true"/>, the parameter value is replaced with the literal string
+    /// <c>[REDACTED]</c>. All other metadata is preserved.
+    /// </param>
+    /// <param name="level">The log level to write the entry at.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> or <paramref name="parameter"/> is <see langword="null"/>.
+    /// </exception>
+    public static void LogDbParameter
+    (
+        this ILogger logger,
+        DbParameter parameter,
+        bool redactValue,
+        LogLevel level
+    )
+    {
+        if (logger is null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        if (parameter is null)
+        {
+            throw new ArgumentNullException(nameof(parameter));
+        }
+
+        if (!logger.IsEnabled(level))
+        {
+            return;
+        }
+
+        var value = redactValue ? (object?)RedactedValue : parameter.Value;
+
+        logger.Log
+        (
+            level,
+            MessageTemplate,
+            parameter.ParameterName,
+            parameter.DbType,
+            parameter.Direction,
+            parameter.Size,
+            parameter.Precision,
+            parameter.Scale,
+            parameter.IsNullable,
+            value
+        );
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/CommandTextLoggerExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/CommandTextLoggerExtensionsTests.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit;
+
+public class CommandTextLoggerExtensionsTests
+{
+    private static IReadOnlyDictionary<string, object?> Params(params (string Name, object? Value)[] items)
+    {
+        var dict = new Dictionary<string, object?>(items.Length);
+        foreach (var (name, value) in items)
+        {
+            dict[name] = value;
+        }
+        return dict;
+    }
+
+
+
+    // ---- Null guards ----
+
+    [Fact]
+    public void LogCommandText_text_only_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogCommandText("SELECT 1"));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_text_with_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogCommandText("SELECT 1", LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_parameters_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogCommandText("SELECT 1", Params()));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_parameters_and_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogCommandText("SELECT 1", Params(), LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_excluded_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogCommandText("SELECT 1", Params(), new[] { "@p" }));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_excluded_and_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogCommandText("SELECT 1", Params(), new[] { "@p" }, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_text_only_when_text_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogCommandText(commandText: null!));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_text_with_level_when_text_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogCommandText(null!, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_parameters_when_text_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogCommandText(null!, Params()));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_parameters_when_parameters_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogCommandText("SELECT 1", parameters: null!));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_parameters_and_excluded_when_parameters_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogCommandText("SELECT 1", parameters: null!, new[] { "@p" }));
+    }
+
+
+
+    // ---- Level filtering ----
+
+    [Fact]
+    public void LogCommandText_text_only_when_log_level_is_disabled_writes_nothing()
+    {
+        var logger = new RecordingLogger { MinimumLevel = LogLevel.Warning };
+
+        logger.LogCommandText("SELECT 1", LogLevel.Information);
+
+        Assert.Empty(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_parameters_when_log_level_is_disabled_writes_nothing()
+    {
+        var logger = new RecordingLogger { MinimumLevel = LogLevel.Warning };
+
+        logger.LogCommandText("SELECT 1", Params(("@p", 1)), LogLevel.Information);
+
+        Assert.Empty(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_text_only_default_overload_logs_at_information()
+    {
+        var logger = new RecordingLogger();
+
+        logger.LogCommandText("SELECT 1");
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_parameters_default_overload_logs_at_information()
+    {
+        var logger = new RecordingLogger();
+
+        logger.LogCommandText("SELECT 1", Params());
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+    }
+
+
+
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public void LogCommandText_text_only_logs_at_specified_level(LogLevel level)
+    {
+        var logger = new RecordingLogger();
+
+        logger.LogCommandText("SELECT 1", level);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(level, entry.Level);
+    }
+
+
+
+    // ---- Content ----
+
+    [Fact]
+    public void LogCommandText_text_only_logs_command_text_field()
+    {
+        var logger = new RecordingLogger();
+
+        logger.LogCommandText("SELECT * FROM Users");
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal("SELECT * FROM Users", entry.GetValue("CommandText"));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_text_only_does_not_include_parameters_field()
+    {
+        var logger = new RecordingLogger();
+
+        logger.LogCommandText("SELECT 1");
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Null(entry.GetValue("Parameters"));
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_empty_parameters_logs_empty_dictionary()
+    {
+        var logger = new RecordingLogger();
+
+        logger.LogCommandText("SELECT 1", Params());
+
+        var entry = Assert.Single(logger.Entries);
+        var parameters = (IReadOnlyDictionary<string, object?>)entry.GetValue("Parameters")!;
+        Assert.Empty(parameters);
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_parameters_logs_command_text_and_parameters()
+    {
+        var logger = new RecordingLogger();
+        var input = Params(("@id", 42), ("@name", "alice"));
+
+        logger.LogCommandText("SELECT * FROM Users WHERE Id=@id AND Name=@name", input);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal("SELECT * FROM Users WHERE Id=@id AND Name=@name", entry.GetValue("CommandText"));
+        var parameters = (IReadOnlyDictionary<string, object?>)entry.GetValue("Parameters")!;
+        Assert.Equal(2, parameters.Count);
+        Assert.Equal(42, parameters["@id"]);
+        Assert.Equal("alice", parameters["@name"]);
+    }
+
+
+
+    // ---- Redaction ----
+
+    [Fact]
+    public void LogCommandText_with_excluded_redacts_only_named_value()
+    {
+        var logger = new RecordingLogger();
+        var input = Params(("@user", "alice"), ("@password", "secret"));
+
+        logger.LogCommandText("CALL Login(@user, @password)", input, new[] { "@password" });
+
+        var entry = Assert.Single(logger.Entries);
+        var parameters = (IReadOnlyDictionary<string, object?>)entry.GetValue("Parameters")!;
+        Assert.Equal("alice", parameters["@user"]);
+        Assert.Equal("[REDACTED]", parameters["@password"]);
+    }
+
+
+
+    [Theory]
+    [InlineData("@password")]
+    [InlineData("password")]
+    [InlineData("PASSWORD")]
+    [InlineData("PassWord")]
+    [InlineData(":password")]
+    [InlineData("?password")]
+    public void LogCommandText_excluded_name_matches_case_insensitively_and_ignores_prefix(string excludedName)
+    {
+        var logger = new RecordingLogger();
+        var input = Params(("@password", "secret"));
+
+        logger.LogCommandText("CALL Login(@password)", input, new[] { excludedName });
+
+        var entry = Assert.Single(logger.Entries);
+        var parameters = (IReadOnlyDictionary<string, object?>)entry.GetValue("Parameters")!;
+        Assert.Equal("[REDACTED]", parameters["@password"]);
+    }
+
+
+
+    [Theory]
+    [InlineData("@password")]
+    [InlineData(":password")]
+    [InlineData("?password")]
+    [InlineData("password")]
+    public void LogCommandText_redacts_dict_key_regardless_of_actual_prefix(string actualKey)
+    {
+        var logger = new RecordingLogger();
+        var input = Params((actualKey, "secret"));
+
+        logger.LogCommandText("CALL Login", input, new[] { "password" });
+
+        var entry = Assert.Single(logger.Entries);
+        var parameters = (IReadOnlyDictionary<string, object?>)entry.GetValue("Parameters")!;
+        Assert.Equal("[REDACTED]", parameters[actualKey]);
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_null_excluded_does_not_redact()
+    {
+        var logger = new RecordingLogger();
+        var input = Params(("@password", "secret"));
+
+        logger.LogCommandText("CALL Login(@password)", input, excludedParameterNames: null);
+
+        var entry = Assert.Single(logger.Entries);
+        var parameters = (IReadOnlyDictionary<string, object?>)entry.GetValue("Parameters")!;
+        Assert.Equal("secret", parameters["@password"]);
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_excluded_and_level_uses_both()
+    {
+        var logger = new RecordingLogger();
+        var input = Params(("@p", "v"));
+
+        logger.LogCommandText("X", input, new[] { "p" }, LogLevel.Warning);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        var parameters = (IReadOnlyDictionary<string, object?>)entry.GetValue("Parameters")!;
+        Assert.Equal("[REDACTED]", parameters["@p"]);
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_with_multiple_excluded_redacts_all_matching_values()
+    {
+        var logger = new RecordingLogger();
+        var input = Params(("@user", "alice"), ("@password", "p1"), ("@token", "t1"));
+
+        logger.LogCommandText("X", input, new[] { "password", "token" });
+
+        var entry = Assert.Single(logger.Entries);
+        var parameters = (IReadOnlyDictionary<string, object?>)entry.GetValue("Parameters")!;
+        Assert.Equal("alice", parameters["@user"]);
+        Assert.Equal("[REDACTED]", parameters["@password"]);
+        Assert.Equal("[REDACTED]", parameters["@token"]);
+    }
+
+
+
+    [Fact]
+    public void LogCommandText_preserves_null_parameter_values_when_not_excluded()
+    {
+        var logger = new RecordingLogger();
+        var input = Params(("@id", null));
+
+        logger.LogCommandText("SELECT * WHERE id=@id", input);
+
+        var entry = Assert.Single(logger.Entries);
+        var parameters = (IReadOnlyDictionary<string, object?>)entry.GetValue("Parameters")!;
+        Assert.Null(parameters["@id"]);
+    }
+
+
+
+    [Fact]
+    public void ApplyRedaction_with_no_excluded_returns_input_dictionary_unchanged()
+    {
+        var input = Params(("@p", 1));
+
+        var result = CommandTextLoggerExtensions.ApplyRedaction(input, excludedParameterNames: null);
+
+        Assert.Same(input, result);
+    }
+
+
+
+    [Fact]
+    public void ApplyRedaction_with_empty_input_returns_input_dictionary_unchanged()
+    {
+        var input = Params();
+
+        var result = CommandTextLoggerExtensions.ApplyRedaction(input, new[] { "anything" });
+
+        Assert.Same(input, result);
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbParameterCollectionLoggerExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbParameterCollectionLoggerExtensionsTests.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit;
+
+public class DbParameterCollectionLoggerExtensionsTests
+{
+    private static FakeDbParameterCollection CreateCollection()
+    {
+        return new FakeDbParameterCollection();
+    }
+
+
+
+    private static FakeDbParameter Add(DbParameterCollection collection, string name, object? value, DbType dbType = DbType.String)
+    {
+        var p = new FakeDbParameter
+        {
+            ParameterName = name,
+            Value = value,
+            DbType = dbType
+        };
+        collection.Add(p);
+        return p;
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameters = CreateCollection();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameterCollection(parameters));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_with_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameters = CreateCollection();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameterCollection(parameters, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_with_excluded_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameters = CreateCollection();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameterCollection(parameters, new[] { "@p" }));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_with_excluded_and_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameters = CreateCollection();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameterCollection(parameters, new[] { "@p" }, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_when_parameters_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameterCollection(parameters: null!));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_with_level_when_parameters_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameterCollection(null!, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_when_log_level_is_disabled_writes_nothing()
+    {
+        var logger = new RecordingLogger { MinimumLevel = LogLevel.Warning };
+        var parameters = CreateCollection();
+
+        logger.LogDbParameterCollection(parameters, LogLevel.Information);
+
+        Assert.Empty(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_default_overload_logs_at_information()
+    {
+        var logger = new RecordingLogger();
+        var parameters = CreateCollection();
+
+        logger.LogDbParameterCollection(parameters);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+    }
+
+
+
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public void LogDbParameterCollection_logs_at_specified_level(LogLevel level)
+    {
+        var logger = new RecordingLogger();
+        var parameters = CreateCollection();
+
+        logger.LogDbParameterCollection(parameters, level);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(level, entry.Level);
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_with_empty_collection_logs_count_zero_and_empty_list()
+    {
+        var logger = new RecordingLogger();
+        var parameters = CreateCollection();
+
+        logger.LogDbParameterCollection(parameters);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(0, entry.GetValue("Count"));
+        var snaps = (IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!;
+        Assert.Empty(snaps);
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_logs_count_and_all_parameters()
+    {
+        var logger = new RecordingLogger();
+        var parameters = CreateCollection();
+        Add(parameters, "@id", 1, DbType.Int32);
+        Add(parameters, "@name", "alice", DbType.String);
+
+        logger.LogDbParameterCollection(parameters);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(2, entry.GetValue("Count"));
+        var snaps = (IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!;
+        Assert.Equal(2, snaps.Count);
+        Assert.Equal("@id", snaps[0].Name);
+        Assert.Equal(1, snaps[0].Value);
+        Assert.Equal("@name", snaps[1].Name);
+        Assert.Equal("alice", snaps[1].Value);
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_redacts_values_for_excluded_names()
+    {
+        var logger = new RecordingLogger();
+        var parameters = CreateCollection();
+        Add(parameters, "@user", "alice");
+        Add(parameters, "@password", "secret");
+
+        logger.LogDbParameterCollection(parameters, new[] { "@password" });
+
+        var entry = Assert.Single(logger.Entries);
+        var snaps = (IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!;
+        Assert.Equal("alice", snaps[0].Value);
+        Assert.Equal("[REDACTED]", snaps[1].Value);
+        Assert.Equal("@password", snaps[1].Name);
+        Assert.Equal(DbType.String, snaps[1].DbType);
+    }
+
+
+
+    [Theory]
+    [InlineData("@password")]
+    [InlineData("password")]
+    [InlineData("PASSWORD")]
+    [InlineData(":password")]
+    [InlineData("?password")]
+    public void LogDbParameterCollection_excluded_name_matches_case_insensitively_and_ignores_prefix(string excludedName)
+    {
+        var logger = new RecordingLogger();
+        var parameters = CreateCollection();
+        Add(parameters, "@password", "secret");
+
+        logger.LogDbParameterCollection(parameters, new[] { excludedName });
+
+        var entry = Assert.Single(logger.Entries);
+        var snap = ((IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!)[0];
+        Assert.Equal("[REDACTED]", snap.Value);
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_with_null_excluded_does_not_redact()
+    {
+        var logger = new RecordingLogger();
+        var parameters = CreateCollection();
+        Add(parameters, "@password", "secret");
+
+        logger.LogDbParameterCollection(parameters, excludedParameterNames: null);
+
+        var entry = Assert.Single(logger.Entries);
+        var snap = ((IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!)[0];
+        Assert.Equal("secret", snap.Value);
+    }
+
+
+
+    [Fact]
+    public void LogDbParameterCollection_with_excluded_and_level_uses_both()
+    {
+        var logger = new RecordingLogger();
+        var parameters = CreateCollection();
+        Add(parameters, "@p", "v");
+
+        logger.LogDbParameterCollection(parameters, new[] { "p" }, LogLevel.Warning);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        var snap = ((IReadOnlyList<LoggedDbParameter>)entry.GetValue("Parameters")!)[0];
+        Assert.Equal("[REDACTED]", snap.Value);
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbParameterLoggerExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbParameterLoggerExtensionsTests.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Data;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Unit;
+
+public class DbParameterLoggerExtensionsTests
+{
+    private static FakeDbParameter CreateParameter()
+    {
+        return new FakeDbParameter
+        {
+            ParameterName = "@id",
+            DbType = DbType.Int32,
+            Direction = ParameterDirection.Input,
+            Size = 4,
+            Precision = 10,
+            Scale = 0,
+            IsNullable = false,
+            Value = 42
+        };
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameter = CreateParameter();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(parameter));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameter = CreateParameter();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(parameter, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameter = CreateParameter();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(parameter, redactValue: true));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_and_level_when_logger_is_null_throws_ArgumentNullException()
+    {
+        ILogger logger = null!;
+        var parameter = CreateParameter();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(parameter, redactValue: true, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_when_parameter_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(parameter: null!));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_level_when_parameter_is_null_throws_ArgumentNullException()
+    {
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() => logger.LogDbParameter(null!, LogLevel.Warning));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_when_log_level_is_disabled_writes_nothing()
+    {
+        var logger = new RecordingLogger { MinimumLevel = LogLevel.Warning };
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, LogLevel.Information);
+
+        Assert.Empty(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_default_overload_logs_at_information()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+    }
+
+
+
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public void LogDbParameter_logs_at_specified_level(LogLevel level)
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, level);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(level, entry.Level);
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_includes_all_metadata_fields()
+    {
+        var logger = new RecordingLogger();
+        var parameter = new FakeDbParameter
+        {
+            ParameterName = "@total",
+            DbType = DbType.Decimal,
+            Direction = ParameterDirection.InputOutput,
+            Size = 9,
+            Precision = 18,
+            Scale = 4,
+            IsNullable = true,
+            Value = 12.34m
+        };
+
+        logger.LogDbParameter(parameter);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal("@total", entry.GetValue("ParameterName"));
+        Assert.Equal(DbType.Decimal, entry.GetValue("DbType"));
+        Assert.Equal(ParameterDirection.InputOutput, entry.GetValue("Direction"));
+        Assert.Equal(9, entry.GetValue("Size"));
+        Assert.Equal((byte)18, entry.GetValue("Precision"));
+        Assert.Equal((byte)4, entry.GetValue("Scale"));
+        Assert.Equal(true, entry.GetValue("IsNullable"));
+        Assert.Equal(12.34m, entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_default_overload_does_not_redact_value()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(42, entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_level_only_does_not_redact_value()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, LogLevel.Warning);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(42, entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_true_replaces_value_with_redacted_marker()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, redactValue: true);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal("[REDACTED]", entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_false_keeps_value()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, redactValue: false);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(42, entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_true_keeps_metadata()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, redactValue: true);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal("@id", entry.GetValue("ParameterName"));
+        Assert.Equal(DbType.Int32, entry.GetValue("DbType"));
+        Assert.Equal(ParameterDirection.Input, entry.GetValue("Direction"));
+        Assert.Equal(4, entry.GetValue("Size"));
+        Assert.Equal((byte)10, entry.GetValue("Precision"));
+        Assert.Equal((byte)0, entry.GetValue("Scale"));
+        Assert.Equal(false, entry.GetValue("IsNullable"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_redact_and_level_uses_both()
+    {
+        var logger = new RecordingLogger();
+        var parameter = CreateParameter();
+
+        logger.LogDbParameter(parameter, redactValue: true, LogLevel.Warning);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal("[REDACTED]", entry.GetValue("Value"));
+    }
+
+
+
+    [Fact]
+    public void LogDbParameter_with_null_value_logs_null()
+    {
+        var logger = new RecordingLogger();
+        var parameter = new FakeDbParameter
+        {
+            ParameterName = "@nullable",
+            Value = null
+        };
+
+        logger.LogDbParameter(parameter);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Null(entry.GetValue("Value"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `LogDbParameterCollection` (four overloads) — emits one structured entry per call with Count + a snapshot of every parameter.
- Delegates parameter snapshotting and redaction to the existing internal helper in `DbCommandLoggerExtensions` so the redaction semantics stay consistent across the library.

## Stacked on Extensions-Logging-Data#7
Base is `feature/log-db-parameter`. Once #4 → #6 → #7 merge upstream the diff narrows.

## Test plan
- [x] Release build clean across all 4 source TFMs — 0 warnings, 0 errors
- [x] All 118 tests pass on 11 TFMs (94 from prior PRs + 24 new)
- [x] Coverage: null guards on every overload, level filtering, count + parameter capture, redaction across name/prefix/case variants, empty collection edge case
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)