### PR TITLE
Exempt Dependabot from protected configuration file guard

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -77,6 +77,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -120,6 +124,11 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
       
       - name: Detect protected configuration file changes
+        # Skip for Dependabot — its bumps to protected files (e.g. Directory.Build.props)
+        # are legitimate. The guard's threat model is human PR authors disabling analyzers
+        # in their own PRs; it does not apply to a trusted GitHub-controlled bot whose
+        # only action is package-version updates.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Checking for changes to protected configuration files in this PR..."
           
@@ -201,6 +210,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -244,6 +257,10 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
 
@@ -550,6 +567,10 @@ jobs:
       
       - name: Fetch trusted configuration files from main branch
         shell: pwsh
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -595,6 +616,10 @@ jobs:
 
       - name: Fetch trusted configuration files from main branch
         shell: pwsh
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
 
@@ -832,6 +857,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -875,6 +904,10 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
 
@@ -1184,6 +1217,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -1227,6 +1264,10 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
 


### PR DESCRIPTION
## Summary

Skips the protected-files guard in `pr.yaml` for Dependabot PRs so weekly analyzer-package bumps land cleanly without manual branch-protection toggling.

## Why

The guard exists to stop **untrusted PR authors** from disabling analyzers in their own PRs. It does **not** apply to Dependabot — a GitHub-controlled bot whose `user.login` (`dependabot[bot]`) is not spoofable from PR contents.

Adds `if: github.event.pull_request.user.login != 'dependabot[bot]'` to:

- **Fetch trusted configuration files from main branch** (in every job — 9 occurrences) — so Dependabot bumps are not silently overwritten by main during build/test
- **Detect protected configuration file changes** (Detect .NET Projects job) — so legitimate bumps do not fail CI

Human PRs continue to be validated identically. Mirror of Chris-Wolfgang/repo-template#315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)