### PR TITLE
dependabot.yml: drop the retired 'dotnet' label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     labels:
-      - "dependencies"    groups:
+      - "dependencies"
+    groups:
       dotnet-dependencies:
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     labels:
-      - "dependencies"
-      - "dotnet"
-    groups:
+      - "dependencies"    groups:
       dotnet-dependencies:
         patterns:
           - "*"


### PR DESCRIPTION
Dependabot is failing every PR creation with:

> `The following labels could not be found: dotnet. Please create it before Dependabot can add it to a pull request.`

The `dotnet` label was retired fleet-wide as part of the canonical cleanup (repo-template#365). This PR removes the remaining references from `.github/dependabot.yml` so Dependabot can keep opening PRs.

Touches only `.github/dependabot.yml` — not a protected path, no admin-bypass needed.

Fleet-wide fix; companion PRs land in every other affected repo.