### PR TITLE
Docs: add canonical favicon + replace {{PROJECT_NAME}} placeholder (closes #109)

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -33,6 +33,7 @@
       {
         "files": [
           "logo.svg",
+          "favicon.svg",
           "images/**"
         ]
       }
@@ -47,6 +48,7 @@
       "_appName": "Wolfgang.Extensions-Logging-Data",
       "_appTitle": "Wolfgang.Extensions-Logging-Data Documentation",
       "_appLogoPath": "logo.svg",
+      "_appFaviconPath": "favicon.svg",
       "_enableSearch": true,
       "_appFooter": "Made with DocFX",
       "_disableSidebar": false,

--- a/docfx_project/docs/index.md
+++ b/docfx_project/docs/index.md
@@ -1,4 +1,4 @@
-# {{PROJECT_NAME}} Documentation
+# Wolfgang.Extensions.Logging.Data Documentation
 
 Welcome to the documentation section. Browse the topics in the navigation menu to get started.
 

--- a/docfx_project/favicon.svg
+++ b/docfx_project/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <style>
+    .w {
+      font-family: Georgia, "Times New Roman", "DejaVu Serif", serif;
+      font-weight: 700;
+      font-size: 30px;
+      fill: #7c23bb;
+      filter: drop-shadow(0 0 2px rgba(124, 35, 187, 0.5));
+    }
+  </style>
+  <text class="w" x="16" y="26" text-anchor="middle">W</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds the canonical purple-W favicon to the rendered docs site and clears one of the unreplaced template placeholders.

## Changes (3 files)

- **`docfx_project/favicon.svg`** — canonical SVG locked in on In-memory-Logger PR #156 (5-iteration design). Matches the navbar serif-W logo identity so the browser-tab icon doesn't look like a generic DocFX install.
- **`docfx_project/docfx.json`** — wired:
  - `"favicon.svg"` added to `resource.files`
  - `"_appFaviconPath": "favicon.svg"` added to `globalMetadata`
- **`docfx_project/docs/index.md`** — replaced unreplaced `{{PROJECT_NAME}}` with `Wolfgang.Extensions.Logging.Data`.

## Issue mapping

- Closes #109 (canonical favicon)
- Partial #77 (placeholder cleanup) — index.md done; README.md placeholders covered by the next stacked PR (D2 README rewrite)

## Stacked on

Base: `vNext`. First in a small stack of docs-focused PRs to close the open Tier-1 docs items.