### PR TITLE
D2: README rewrite (closes #48, #64, #45, finishes #77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# Wolfgang.Extensions-Logging-Data
+# Wolfgang.Extensions.Logging.Data
 
-Exntension methods to ILogger and ILogger<T> for logging DbConnection, DbCommand, and other System.Data related data
+Extension methods on `ILogger` for logging `DbConnection`, `DbCommand`, and other `System.Data` types — with credential redaction baked in so passwords never reach the log.
 
+[![NuGet](https://img.shields.io/nuget/v/Wolfgang.Extensions.Logging.Data.svg?logo=nuget&label=NuGet)](https://www.nuget.org/packages/Wolfgang.Extensions.Logging.Data)
+[![NuGet downloads](https://img.shields.io/nuget/dt/Wolfgang.Extensions.Logging.Data.svg?logo=nuget&label=downloads)](https://www.nuget.org/packages/Wolfgang.Extensions.Logging.Data)
+[![PR build](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/Extensions-Logging-Data/pr.yaml?event=pull_request_target&label=PR%20build&logo=github)](https://github.com/Chris-Wolfgang/Extensions-Logging-Data/actions/workflows/pr.yaml)
+[![Release](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/Extensions-Logging-Data/release.yaml?label=release&logo=github)](https://github.com/Chris-Wolfgang/Extensions-Logging-Data/actions/workflows/release.yaml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
 [![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github)](https://github.com/Chris-Wolfgang/Extensions-Logging-Data)
@@ -11,10 +15,10 @@ Exntension methods to ILogger and ILogger<T> for logging DbConnection, DbCommand
 ## 📦 Installation
 
 ```bash
-dotnet add package Wolfgang.Extensions-Logging-Data
+dotnet add package Wolfgang.Extensions.Logging.Data
 ```
 
-**NuGet Package:** Coming soon to NuGet.org
+**NuGet Package:** [Wolfgang.Extensions.Logging.Data](https://www.nuget.org/packages/Wolfgang.Extensions.Logging.Data)
 
 ---
 
@@ -28,154 +32,135 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 
 - **GitHub Repository:** [https://github.com/Chris-Wolfgang/Extensions-Logging-Data](https://github.com/Chris-Wolfgang/Extensions-Logging-Data)
 - **API Documentation:** https://Chris-Wolfgang.github.io/Extensions-Logging-Data/
-- **Formatting Guide:** [README-FORMATTING.md](README-FORMATTING.md)
+- **CHANGELOG:** [CHANGELOG.md](CHANGELOG.md)
 - **Contributing Guide:** [CONTRIBUTING.md](CONTRIBUTING.md)
+- **DocFX Version Picker Troubleshooting:** [docs/DOCFX-VERSION-PICKER.md](docs/DOCFX-VERSION-PICKER.md)
 
 ---
 
 ## 🚀 Quick Start
 
-{{QUICK_START_EXAMPLE}}
+```csharp
+using System.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data;
+
+ILogger logger = /* … your DI-resolved ILogger … */;
+
+using var connection = new SqlConnection(connectionString);
+await connection.OpenAsync();
+
+// Logs one structured entry: ConnectionType, Database, DataSource,
+// ServerVersion, State, ConnectionTimeout, ConnectionString — with
+// Password / Pwd keys removed before the entry is written.
+logger.LogDbConnection(connection);
+```
+
+Want it at a different level than the default `Information`? Pass one:
+
+```csharp
+logger.LogDbConnection(connection, LogLevel.Debug);
+```
 
 ---
 
 ## ✨ Features
 
-{{FEATURES_TABLE}}
+| Feature | Method |
+|---|---|
+| Log a `DbConnection` at `LogLevel.Information` (default) | `ILogger.LogDbConnection(DbConnection)` |
+| Log a `DbConnection` at a specific `LogLevel` | `ILogger.LogDbConnection(DbConnection, LogLevel)` |
+| **Credential redaction** — `Password` / `Pwd` keys are stripped from the connection string before it's emitted | (built-in to every overload) |
+| **Structured logging** — emits as templated log entry with named properties (`{ConnectionType}`, `{Database}`, `{DataSource}`, etc.) for structured-log sinks like Serilog, Application Insights, or Elastic | (built-in) |
+| **`IsEnabled(level)` short-circuit** — work is skipped if the log level isn't enabled, so the redaction / `DbConnectionStringBuilder` parse only runs when the entry will actually be written | (built-in) |
+| **Null-safe** — throws `ArgumentNullException` (not `NullReferenceException`) when `logger` or `connection` is `null` | (every overload) |
 
-**Examples:**
-{{FEATURE_EXAMPLES}}
+**Roadmap:** `DbCommand` and additional `System.Data` types are next on the surface. The library is intentionally narrow today and grows one type at a time as needed.
 
 ---
 
 ## 🎯 Target Frameworks
 
-| Framework | Versions |
-|-----------|----------|
-| .NET Framework | .NET 4.6.2, .NET 4.7.0, .NET 4.7.1, .NET 4.7.2, .NET 4.8, .NET 4.8.1 |
-| .NET Core | .NET Core 3.1 |
-| .NET | .NET 5.0, .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0, .NET 10.0 |
+| Family | Targets |
+|---|---|
+| .NET Framework | `net462` |
+| .NET Standard | `netstandard2.0`, `netstandard2.1` |
+| Modern .NET | `net10.0` |
+
+`net462` is included so the library is usable from .NET Framework 4.6.2+ application hosts (existing `System.Data.SqlClient` consumers, classic web apps).
 
 ---
 
 ## 🔍 Code Quality & Static Analysis
 
-This project enforces **strict code quality standards** through **7 specialized analyzers** and custom async-first rules:
+This project enforces strict code quality standards through **7 specialized analyzers** and async-first custom rules:
 
-### Analyzers in Use
-
-1. **Microsoft.CodeAnalysis.NetAnalyzers** - Built-in .NET analyzers for correctness and performance
-2. **Roslynator.Analyzers** - Advanced refactoring and code quality rules
-3. **AsyncFixer** - Async/await best practices and anti-pattern detection
-4. **Microsoft.VisualStudio.Threading.Analyzers** - Thread safety and async patterns
-5. **Microsoft.CodeAnalysis.BannedApiAnalyzers** - Prevents usage of banned synchronous APIs
-6. **Meziantou.Analyzer** - Comprehensive code quality rules
-7. **SonarAnalyzer.CSharp** - Industry-standard code analysis
+1. **Microsoft.CodeAnalysis.NetAnalyzers** — built-in .NET analyzers for correctness and performance
+2. **Roslynator.Analyzers** — advanced refactoring and code quality rules
+3. **AsyncFixer** — async/await best practices and anti-pattern detection
+4. **Microsoft.VisualStudio.Threading.Analyzers** — thread safety and async patterns
+5. **Microsoft.CodeAnalysis.BannedApiAnalyzers** — prevents usage of banned synchronous APIs
+6. **Meziantou.Analyzer** — comprehensive code quality rules
+7. **SonarAnalyzer.CSharp** — industry-standard code analysis
 
 ### Async-First Enforcement
 
-This library uses **`BannedSymbols.txt`** to prohibit synchronous APIs and enforce async-first patterns:
+The repo uses **`BannedSymbols.txt`** to prohibit blocking APIs:
 
-**Blocked APIs Include:**
-- ❌ `Task.Wait()`, `Task.Result` - Use `await` instead
-- ❌ `Thread.Sleep()` - Use `await Task.Delay()` instead
-- ❌ Synchronous file I/O (`File.ReadAllText`) - Use async versions
-- ❌ Synchronous stream operations - Use `ReadAsync()`, `WriteAsync()`
-- ❌ `Parallel.For/ForEach` - Use `Task.WhenAll()` or `Parallel.ForEachAsync()`
+- ❌ `Task.Wait()`, `Task.Result` — use `await`
+- ❌ `Thread.Sleep()` — use `await Task.Delay()`
+- ❌ Synchronous file I/O (`File.ReadAllText`) — use async equivalents
+- ❌ Synchronous stream operations — use `ReadAsync()` / `WriteAsync()`
+- ❌ `Parallel.For` / `Parallel.ForEach` — use `Task.WhenAll()` or `Parallel.ForEachAsync()`
 - ❌ Obsolete APIs (`WebClient`, `BinaryFormatter`)
-
-**Why?** To ensure all code is **truly async** and **non-blocking** for optimal performance in async contexts.
 
 ---
 
 ## 🛠️ Building from Source
 
 ### Prerequisites
-- [.NET 8.0 SDK](https://dotnet.microsoft.com/download) or later
-- Optional: [PowerShell Core](https://github.com/PowerShell/PowerShell) for formatting scripts
 
-### Build Steps
+- .NET 10.0 SDK (also need .NET 8 / 9 SDKs to run the full multi-targeting test matrix)
+- Optional: [PowerShell Core](https://github.com/PowerShell/PowerShell) for the formatting / build helper scripts
+
+### Build steps
 
 ```bash
-# Clone the repository
+# Clone
 git clone https://github.com/Chris-Wolfgang/Extensions-Logging-Data.git
 cd Extensions-Logging-Data
 
-# Restore dependencies
+# Restore + build + test
 dotnet restore
-
-# Build the solution
 dotnet build --configuration Release
+dotnet test  --configuration Release
 
-# Run tests
-dotnet test --configuration Release
-
-# Run code formatting (PowerShell Core)
-pwsh ./format.ps1
+# Format (PowerShell Core)
+pwsh ./scripts/format.ps1
 ```
 
-### Code Formatting
-
-This project uses `.editorconfig` and `dotnet format`:
+### Building documentation locally
 
 ```bash
-# Format code
-dotnet format
+# Install DocFX once
+dotnet tool update -g docfx
 
-# Verify formatting (as CI does)
-dotnet format --verify-no-changes
-```
-
-See [README-FORMATTING.md](README-FORMATTING.md) for detailed formatting guidelines.
-
-### Building Documentation
-
-This project uses [DocFX](https://dotnet.github.io/docfx/) to generate API documentation:
-
-```bash
-# Install DocFX (one-time setup)
-dotnet tool install -g docfx
-
-# Generate API metadata and build documentation
+# Build + serve
 cd docfx_project
-docfx metadata  # Extract API metadata from source code
-docfx build     # Build HTML documentation
-
-# Documentation is generated in the docs/ folder at the repository root
+docfx metadata
+docfx build --serve   # http://localhost:8080
 ```
-
-The documentation is automatically built and deployed to GitHub Pages when changes are pushed to the `main` branch.
-
-**Local Preview:**
-```bash
-# Serve documentation locally (with live reload)
-cd docfx_project
-docfx build --serve
-
-# Open http://localhost:8080 in your browser
-```
-
-**Documentation Structure:**
-- `docfx_project/` - DocFX configuration and source files
-- `docs/` - Generated HTML documentation (published to GitHub Pages)
-- `docfx_project/index.md` - Main landing page content
-- `docfx_project/docs/` - Additional documentation articles
-- `docfx_project/api/` - Auto-generated API reference YAML files
 
 ---
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:
-- Code quality standards
-- Build and test instructions
-- Pull request guidelines
-- Analyzer configuration details
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for code quality standards, build and test instructions, pull request guidelines, and analyzer configuration details.
 
 ---
 
-
 ## 🙏 Acknowledgments
 
-{{ACKNOWLEDGMENTS}}
-
+- **[Microsoft.Extensions.Logging](https://learn.microsoft.com/dotnet/core/extensions/logging)** — the `ILogger` abstraction this library extends
+- **[System.Data.Common.DbConnectionStringBuilder](https://learn.microsoft.com/dotnet/api/system.data.common.dbconnectionstringbuilder)** — the parser the redaction logic is built around
+- The broader Wolfgang.Extensions.* family for the canonical CI / docs / packaging patterns this repo inherits


### PR DESCRIPTION
## Summary

Substantial README rewrite — replaces the template-stub README that still carried unreplaced `{{...}}` placeholders, a typo'd title, and a wrong package id.

## Drift fixed

1. **Title** — `Wolfgang.Extensions-Logging-Data` → `Wolfgang.Extensions.Logging.Data` to match the actual NuGet package id (dots, not dashes).
2. **Tagline typo** — `Exntension methods to ILogger` → `Extension methods on ILogger`. Also surfaces the credential-redaction feature which is the library's main differentiator.
3. **Badges** — added the canonical six-badge collection matching the rest of the Wolfgang.* fleet (NuGet, downloads, PR build with `event=pull_request_target` filter, release, License, .NET, GitHub).
4. **Installation** — package id corrected, NuGet link wired up (replaces "Coming soon to NuGet.org").
5. **Quick Start** — concrete working example using the actual `LogDbConnection(this ILogger, DbConnection)` overload, plus the level-override overload. Replaces `{{QUICK_START_EXAMPLE}}`.
6. **Features** — accurate table of the current public surface (2 overloads + built-in redaction / structured-logging / `IsEnabled` short-circuit / null guards). Notes the `DbCommand`-and-other-`System.Data` roadmap. Replaces both `{{FEATURES_TABLE}}` and `{{FEATURE_EXAMPLES}}`.
7. **Target Frameworks** — corrected to the actual TFM list (`net462`, `netstandard2.0`, `netstandard2.1`, `net10.0`) — the prior table claimed support for net47/net471/net472/net48/net481, netcoreapp3.1, net5.0–net9.0 which the csproj doesn't target.
8. **Building** — `pwsh` path corrected to `scripts/format.ps1`; `docfx tool` command changed to `update` (idempotent reinstall).
9. **Acknowledgments** — replaces `{{ACKNOWLEDGMENTS}}` placeholder with concrete credits (Microsoft.Extensions.Logging, `DbConnectionStringBuilder`, the broader fleet).

## Issue mapping

- Closes #45 (standardize README structure)
- Closes #48 (D2 audit README accuracy)
- Closes #64 (D2 README accuracy fixes)
- Finishes #77 — the docfx index.md placeholder went in the prior stacked PR #111; this one clears the README placeholders

## Stacked on

Base: `vNext`. Second in the docs-cleanup stack. PR #111 (favicon + docfx-index placeholder) is the first.