### PR TITLE
C5: AI code-review pass on DbConnectionLoggerExtensions.cs (closes #38)

### DIFF
--- a/src/Wolfgang.Extensions.Logging.Data/DbConnectionLoggerExtensions.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/DbConnectionLoggerExtensions.cs
@@ -11,8 +11,10 @@ namespace Wolfgang.Extensions.Logging.Data;
 /// <remarks>
 /// The <see cref="DbConnection.ConnectionString"/> is parsed via
 /// <see cref="DbConnectionStringBuilder"/> and the <c>Password</c> and <c>Pwd</c> keys are
-/// removed before logging so credentials are never written to the log. All other keys,
-/// including the user name (<c>User ID</c>, <c>UID</c>, etc.), are preserved.
+/// removed before logging so credentials are never written to the log. Key matching is
+/// case-insensitive per the <see cref="DbConnectionStringBuilder"/> contract, so
+/// <c>password</c>, <c>PASSWORD</c>, etc. are all redacted. All other keys, including the
+/// user name (<c>User ID</c>, <c>UID</c>, etc.), are preserved.
 /// </remarks>
 public static class DbConnectionLoggerExtensions
 {
@@ -54,6 +56,13 @@ public static class DbConnectionLoggerExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="logger"/> or <paramref name="connection"/> is <see langword="null"/>.
     /// </exception>
+    /// <example>
+    /// <code>
+    /// using var connection = new SqlConnection(connectionString);
+    /// await connection.OpenAsync();
+    /// logger.LogDbConnection(connection, LogLevel.Debug);
+    /// </code>
+    /// </example>
     public static void LogDbConnection(this ILogger logger, DbConnection connection, LogLevel level)
     {
         if (logger is null)
@@ -111,15 +120,12 @@ public static class DbConnectionLoggerExtensions
             ConnectionString = connectionString
         };
 
-        if (builder.ContainsKey("Password"))
-        {
-            builder.Remove("Password");
-        }
-
-        if (builder.ContainsKey("Pwd"))
-        {
-            builder.Remove("Pwd");
-        }
+        // DbConnectionStringBuilder.Remove is a no-op for keys that aren't present
+        // (returns false rather than throwing), so the ContainsKey checks would be
+        // redundant. Key matching is case-insensitive per the type contract, so
+        // "password" / "PASSWORD" / etc. are removed by either call.
+        builder.Remove("Password");
+        builder.Remove("Pwd");
 
         return builder.ConnectionString ?? string.Empty;
     }


### PR DESCRIPTION
## Summary

Three small improvements from an AI code-review pass on the only source file in this library. **No behavior change.**

## Changes

### 1. `RedactConnectionString` — drop redundant `ContainsKey` checks

```diff
- if (builder.ContainsKey("Password")) { builder.Remove("Password"); }
- if (builder.ContainsKey("Pwd"))      { builder.Remove("Pwd"); }
+ builder.Remove("Password");
+ builder.Remove("Pwd");
```

`DbConnectionStringBuilder.Remove` is documented to return `false` (not throw) when the key is absent, so the `ContainsKey` checks are dead defensive code. Net **−6 lines**. Inline comment explains why the checks are unnecessary so a future reader doesn't "helpfully" re-add them, and that key matching is case-insensitive per the type contract.

### 2. Class-level XML `<remarks>` — clarify case-insensitive matching

Tightened the password-redaction description to explicitly call out that `password`, `PASSWORD`, etc. are all redacted by the same two `Remove` calls. The previous wording left the case-sensitivity question ambiguous.

### 3. `LogDbConnection(ILogger, DbConnection, LogLevel)` — add `<example>` XML block

Parity with the single-arg overload. The explicit-level overload had no inline example, so a reader browsing the API reference for it would have to bounce over to the default-level overload to see usage.

## Issue mapping

- Closes #38 (cleanup: Run an AI full code-review pass)

## Stacked on

Base: `vNext`. Fourth in the docs/cleanup stack (#111 favicon, #112 README, #113 markdown audit).

## What was NOT changed (deliberately)

- `connection.GetType().FullName` lookup per call — could be cached but the `IsEnabled(level)` short-circuit already gates the cost; not worth a static dictionary.
- `<example>` block uses `using var connection = new SqlConnection(...)` without specifying `System.Data.SqlClient` vs `Microsoft.Data.SqlClient` — kept ambiguous because both work and the library is provider-neutral.
- `TryGetServerVersion` only catches `InvalidOperationException` — other providers may throw `NotSupportedException`. Real-world coverage requires per-provider testing; not in scope for a code-review pass.