### PR TITLE
P1 + benchmarks/.editorconfig: stand up BDN baseline (closes #40, #62)

### DIFF
--- a/Extensions-Logging-Data.slnx
+++ b/Extensions-Logging-Data.slnx
@@ -40,7 +40,10 @@
     <File Path="scripts/Setup-Labels.ps1" />
     <File Path="scripts/setup.ps1" />
   </Folder>
-  <Folder Name="/benchmarks/" />
+  <Folder Name="/benchmarks/">
+    <File Path="benchmarks/.editorconfig" />
+    <Project Path="benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/examples/" />
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj" />

--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,0 +1,64 @@
+# Curated overrides for benchmark projects.
+#
+# BenchmarkDotNet code intentionally trips analyzers that are correct
+# for shipped library code but wrong for measurement harnesses:
+#   - `[Benchmark]` methods are invoked by reflection, so most "unused"
+#     warnings are false positives
+#   - the deliberately-naive measured code triggers async-first /
+#     allocation / banned-API rules that would otherwise mask the very
+#     thing we're trying to measure
+#   - GC.GetTotalMemory / Stopwatch-pattern measurement code looks
+#     suspicious to a thread-safety analyzer but is the canonical BDN
+#     pattern
+#
+# Rather than dropping TreatWarningsAsErrors for benchmarks (which would
+# also hide real bugs in the benchmark harness), this file disables the
+# specific rules that BDN code consistently breaks. Add new entries here
+# instead of editing per-csproj <NoWarn>.
+
+root = false
+
+[*.cs]
+
+# CA1822 — "member can be made static" fires on every [Benchmark] method
+# (BDN requires them to be instance methods so it can resolve fields).
+dotnet_diagnostic.CA1822.severity = none
+
+# CA1024 — "use property" fires on [Benchmark]-attributed methods that
+# look like getters. They aren't; they're measurement entry points.
+dotnet_diagnostic.CA1024.severity = none
+
+# CA1812 — "internal class is never instantiated" — BDN instantiates
+# benchmark classes by reflection, so the static analyzer can't see it.
+dotnet_diagnostic.CA1812.severity = none
+
+# CA2007 — ConfigureAwait warnings — benchmark code intentionally awaits
+# without ConfigureAwait(false) so the measured cost matches application
+# code rather than library code.
+dotnet_diagnostic.CA2007.severity = none
+
+# Meziantou MA0004 — same rationale as CA2007.
+dotnet_diagnostic.MA0004.severity = none
+
+# Roslynator RCS1213 — "remove unused member" fires on private helpers
+# that BenchmarkDotNet's [GlobalSetup] / [IterationSetup] discovers via
+# attribute, which the analyzer can't see.
+dotnet_diagnostic.RCS1213.severity = none
+
+# CS1591 — missing XML doc. Benchmarks are not part of the shipping
+# public surface; XML docs on every [Benchmark] method would be noise.
+dotnet_diagnostic.CS1591.severity = none
+
+# CA1707 — identifier names contain underscores. The canonical BDN
+# benchmark-method naming is "Method_Scenario" (e.g.
+# LogDbConnection_DisabledLogger_FastPath) so chart legends are
+# self-describing.
+dotnet_diagnostic.CA1707.severity = none
+
+# CA1051 — "do not declare visible instance fields" — measurement
+# harnesses use public fields to expose [Params] etc.
+dotnet_diagnostic.CA1051.severity = none
+
+# CA1849 — "call sync APIs in async context" — benchmark methods often
+# need to compare sync vs async measured paths side by side.
+dotnet_diagnostic.CA1849.severity = none

--- a/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/DbConnectionLoggerExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/DbConnectionLoggerExtensionsBenchmarks.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wolfgang.Extensions.Logging.Data;
+
+namespace Wolfgang.Extensions.Logging.Data.Benchmarks;
+
+/// <summary>
+/// Microbenchmarks for the public extension methods. Two scenarios are
+/// measured:
+///
+/// 1. The IsEnabled fast-path — the logger returns false on IsEnabled, so
+///    LogDbConnection should short-circuit before doing the connection-
+///    string redaction work. This is the dominant production cost (almost
+///    every call site is gated by a log level that's not enabled).
+///
+/// 2. The full work path — the logger returns true on IsEnabled, so the
+///    redaction + Log call run. This is what hits when the log entry
+///    actually gets written.
+///
+/// MemoryDiagnoser is enabled so any future refactor that introduces
+/// allocation surfaces in the gh-pages benchmark chart immediately.
+/// </summary>
+[MemoryDiagnoser]
+public class DbConnectionLoggerExtensionsBenchmarks
+{
+    private static readonly ILogger DisabledLogger = NullLogger.Instance;
+    private static readonly ILogger EnabledLogger = new EnabledMemoryLogger();
+    private static readonly DbConnection SampleConnection = new SampleDbConnection(
+        connectionString: "Server=tcp:sample.example.com,1433;Database=widgets;User ID=app;Password=hunter2;TrustServerCertificate=true;");
+
+
+
+    [Benchmark(Baseline = true)]
+    public void LogDbConnection_DisabledLogger_FastPath()
+    {
+        DisabledLogger.LogDbConnection(SampleConnection);
+    }
+
+
+
+    [Benchmark]
+    public void LogDbConnection_EnabledLogger_FullWork()
+    {
+        EnabledLogger.LogDbConnection(SampleConnection);
+    }
+
+
+
+    [Benchmark]
+    public void LogDbConnection_EnabledLogger_ExplicitDebugLevel()
+    {
+        EnabledLogger.LogDbConnection(SampleConnection, LogLevel.Debug);
+    }
+
+
+
+    /// <summary>
+    /// Logger that returns true for every IsEnabled call but discards the log
+    /// payload. Lets the benchmark measure the redaction + Log invocation
+    /// without coupling to any concrete sink implementation.
+    /// </summary>
+    private sealed class EnabledMemoryLogger : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            // Force the formatter to run so the benchmark also captures the
+            // structured-message render cost rather than only the dispatch.
+            _ = formatter(state, exception);
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+
+
+    /// <summary>
+    /// Minimal DbConnection used only as a benchmark input. Implements the
+    /// handful of properties LogDbConnection reads (ConnectionString,
+    /// Database, DataSource, State, ConnectionTimeout) with canned values
+    /// representative of a typical SQL connection. ServerVersion throws
+    /// InvalidOperationException so the TryGetServerVersion catch branch is
+    /// exercised at least sometimes.
+    /// </summary>
+    private sealed class SampleDbConnection : DbConnection
+    {
+        public SampleDbConnection(string connectionString)
+        {
+            ConnectionString = connectionString;
+        }
+
+        public override string ConnectionString { get; set; }
+
+        public override string Database => "widgets";
+
+        public override string DataSource => "tcp:sample.example.com,1433";
+
+        public override string ServerVersion => throw new InvalidOperationException("Connection not open.");
+
+        public override ConnectionState State => ConnectionState.Closed;
+
+        public override void ChangeDatabase(string databaseName)
+        {
+        }
+
+        public override void Close()
+        {
+        }
+
+        public override void Open()
+        {
+        }
+
+        protected override DbCommand CreateDbCommand() => throw new NotSupportedException();
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new NotSupportedException();
+    }
+}

--- a/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/Program.cs
+++ b/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.Logging.Data\Wolfgang.Extensions.Logging.Data.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>


### PR DESCRIPTION
## Summary

Stands up the BenchmarkDotNet baseline project so the gh-pages chart workflow (#41) has something to consume once it lands. Also closes #62 by holding the benchmark project to `TreatWarningsAsErrors` via a curated per-rule carve-out instead of an across-the-board `TWEA=false`.

## Benchmarks

| Method | What it measures |
|---|---|
| `LogDbConnection_DisabledLogger_FastPath` (baseline) | `IsEnabled` short-circuit — the dominant production cost |
| `LogDbConnection_EnabledLogger_FullWork` | Redaction + structured `Log` invocation, formatter materialized |
| `LogDbConnection_EnabledLogger_ExplicitDebugLevel` | Same as full-work but via the explicit-level overload |

`MemoryDiagnoser` is on so any future refactor that introduces allocation surfaces in the chart immediately (the redaction path's `DbConnectionStringBuilder` allocation is the obvious one to watch).

## Scaffolding shipped alongside

- **`SampleDbConnection`** — minimal `DbConnection` implementing only the properties `LogDbConnection` reads, with canned values representative of a SQL connection. Avoids pulling in `Microsoft.Data.Sqlite` (or any concrete provider) just to feed the benchmark.
- **`EnabledMemoryLogger`** — `ILogger` that returns `true` on `IsEnabled` and runs the formatter but discards the payload, so the measurement captures redaction + template-render cost without coupling to a concrete sink.

## `benchmarks/.editorconfig` carve-outs

Closes #62 with per-rule overrides rather than disabling `TreatWarningsAsErrors`. The disabled rules are only those BDN code consistently breaks:

| Rule | Why disabled in benchmarks |
|---|---|
| CA1822 | `[Benchmark]` methods must be instance methods |
| CA1024 | `[Benchmark]` methods look like getters but aren't |
| CA1812 | BDN instantiates benchmark classes via reflection |
| CA2007 / MA0004 | Benchmark code intentionally awaits without `ConfigureAwait(false)` to mirror application call sites |
| RCS1213 | `[GlobalSetup]` / `[IterationSetup]` helpers discovered via attribute |
| CS1591 | Benchmarks aren't part of the shipping public surface |
| CA1707 | Canonical BDN naming is `Method_Scenario` so chart legends self-describe |
| CA1051 | `[Params]` fields are public by convention |
| CA1849 | Sync vs async measurement paths often need to coexist |

## Issue mapping

- Closes #40 (P1 BDN baseline)
- Closes #62 (benchmarks `.editorconfig`)
- Sets up #41 (BDN chart workflow) — needs the `add-benchmarks-workflow` skill in a separate PR

## Stacked on

Base: `vNext`. Fifth in the stack.