### PR TITLE
T4: test-quality audit pass — fill 3 coverage gaps (closes #67)

### DIFF
--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbConnectionLoggerExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbConnectionLoggerExtensionsTests.cs
@@ -279,4 +279,72 @@ public class DbConnectionLoggerExtensionsTests
         Assert.DoesNotContain("p1", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("p2", redacted, StringComparison.OrdinalIgnoreCase);
     }
+
+
+
+    // T4 (test-quality audit) gap-fill: the prior suite verified every
+    // logged FIELD individually, but never asserted that the structured
+    // log entry actually carries all SEVEN named properties the
+    // MessageTemplate declares. A future refactor that drops a parameter
+    // from the template would not have been caught.
+    [Fact]
+    public void LogDbConnection_emits_all_seven_named_log_properties()
+    {
+        var logger = new RecordingLogger();
+        var connection = new FakeDbConnection();
+
+        logger.LogDbConnection(connection);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.NotNull(entry.GetValue("ConnectionType"));
+        // Database/DataSource may be empty strings from the FakeDbConnection
+        // defaults but the named slot must exist.
+        Assert.True(entry.ContainsKey("Database"));
+        Assert.True(entry.ContainsKey("DataSource"));
+        Assert.True(entry.ContainsKey("ServerVersion"));
+        Assert.True(entry.ContainsKey("State"));
+        Assert.True(entry.ContainsKey("ConnectionTimeout"));
+        Assert.True(entry.ContainsKey("ConnectionString"));
+    }
+
+
+
+    // T4 gap-fill: connection.ConnectionString may be null at the source
+    // (e.g. a freshly-constructed DbConnection before any setter call).
+    // The redaction layer turns null into string.Empty; verify the logged
+    // value reflects that rather than NRE'ing or leaking 'null'.
+    [Fact]
+    public void LogDbConnection_when_connection_string_is_null_logs_empty_string()
+    {
+        var logger = new RecordingLogger();
+        var connection = new FakeDbConnection { ConnectionString = null! };
+
+        logger.LogDbConnection(connection);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(string.Empty, entry.GetValue("ConnectionString"));
+    }
+
+
+
+    // T4 gap-fill: the redaction round-trips through
+    // DbConnectionStringBuilder — verify the output is itself a parseable
+    // connection string (not malformed mid-redaction by stray semicolons,
+    // quoting issues, etc.). The other RedactConnectionString_* tests
+    // parse the result as a side check; this one makes the assertion the
+    // intent.
+    [Fact]
+    public void RedactConnectionString_output_is_parseable_via_DbConnectionStringBuilder()
+    {
+        var redacted = DbConnectionLoggerExtensions.RedactConnectionString(
+            "Server=foo;Database=bar;User ID=bob;Password=hunter2;Connect Timeout=15");
+
+        // No exception = the output is well-formed key=value;key=value pairs.
+        var parsed = new DbConnectionStringBuilder { ConnectionString = redacted };
+
+        Assert.Equal("foo", parsed["Server"]);
+        Assert.Equal("bar", parsed["Database"]);
+        Assert.Equal("bob", parsed["User ID"]);
+        Assert.Equal("15", parsed["Connect Timeout"]);
+    }
 }

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/LogEntry.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/LogEntry.cs
@@ -49,4 +49,29 @@ internal sealed class LogEntry
 
         return null;
     }
+
+    /// <summary>
+    /// True when the structured-log values list contains the named property,
+    /// regardless of whether the value is <see langword="null"/>. Used by
+    /// tests that need to distinguish 'name present, value null' from
+    /// 'name absent entirely' (the latter is a message-template regression
+    /// that <see cref="GetValue(string)"/> can't surface on its own).
+    /// </summary>
+    public bool ContainsKey(string name)
+    {
+        if (Values is null)
+        {
+            return false;
+        }
+
+        foreach (var kvp in Values)
+        {
+            if (string.Equals(kvp.Key, name, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary

T4 audit of the existing 21-test suite in `DbConnectionLoggerExtensionsTests.cs`. The existing tests cover the obvious surface (null guards, every `LogLevel` value, disabled-level fast path, every individual logged field, redaction positive + negative + case-insensitivity cases). Naming follows the canonical `Method_when_condition_expected_result` pattern, Allman braces, file-scoped namespaces — fully CLAUDE.md compliant.

## Three gaps spotted + filled

### 1. `LogDbConnection_emits_all_seven_named_log_properties`
The prior suite checked every logged **field** individually but never asserted that the structured log entry actually carries all seven named properties the `MessageTemplate` declares. A future refactor that drops a parameter from the template would slip through unnoticed.

Required a small TestHelper addition: `LogEntry.ContainsKey(string)` distinguishes "name present, value null" from "name absent entirely" — `GetValue` alone can't, since it returns null for both.

### 2. `LogDbConnection_when_connection_string_is_null_logs_empty_string`
`DbConnection.ConnectionString` can be `null` (freshly-constructed instances). The redaction layer turns null into `string.Empty`; the test verifies the logged value reflects that rather than leaking the literal string `"null"` or NRE'ing.

### 3. `RedactConnectionString_output_is_parseable_via_DbConnectionStringBuilder`
Existing `RedactConnectionString_*` tests parse the redaction output as a side check (to assert key/value presence); this one makes parseability the **intent**. Guards against a hypothetical redaction implementation that strips a key without restoring the surrounding semicolon structure.

## Issue mapping

- Closes #67 (T4 test quality audit)

## Stacked on

Base: `vNext`. Sixth in the stack.