### PR TITLE
Add integration test suite via Microsoft.Data.Sqlite (closes #43)

### DIFF
--- a/Extensions-Logging-Data.slnx
+++ b/Extensions-Logging-Data.slnx
@@ -46,6 +46,7 @@
     <Project Path="src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/Wolfgang.Extensions.Logging.Data.Tests.Integration.csproj" />
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj" />
   </Folder>
 </Solution>

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/DbConnectionLoggerIntegrationTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/DbConnectionLoggerIntegrationTests.cs
@@ -1,0 +1,182 @@
+using System.Collections.Generic;
+using System.Data;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Integration;
+
+/// <summary>
+/// End-to-end integration tests that exercise <c>LogDbConnection</c> with:
+///   - a real <see cref="DbConnection"/> implementation (Microsoft.Data.Sqlite),
+///   - a real <see cref="LoggerFactory"/> with a structured-capturing provider.
+///
+/// Where the unit tests use hand-rolled fakes for both, these tests prove the
+/// extension method works against the production .NET logging pipeline and a
+/// production ADO.NET provider — so a regression in either contract surfaces
+/// here without needing the unit-test fakes to track it.
+/// </summary>
+public class DbConnectionLoggerIntegrationTests
+{
+    [Fact]
+    public void LogDbConnection_against_open_sqlite_connection_emits_a_structured_entry()
+    {
+        var provider = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(provider);
+        });
+        var logger = factory.CreateLogger<DbConnectionLoggerIntegrationTests>();
+
+        using var connection = new SqliteConnection("Data Source=:memory:;Password=topsecret");
+        connection.Open();
+
+        logger.LogDbConnection(connection);
+
+        var entry = Assert.Single(provider.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+
+        // Real connection — values come from Microsoft.Data.Sqlite, not a fake.
+        Assert.Equal(":memory:", entry.GetValue("DataSource"));
+        Assert.Equal(ConnectionState.Open, entry.GetValue("State"));
+        Assert.NotNull(entry.GetValue("ConnectionType"));   // typeof(SqliteConnection).FullName
+        Assert.NotNull(entry.GetValue("ServerVersion"));     // SQLite reports its lib version once Open
+
+        // The Password key in the connection string must be redacted from the
+        // logged value (this is the whole point of the library). The redaction
+        // path here goes through Microsoft.Data.Sqlite's
+        // SqliteConnection.ConnectionString — which normalizes keys — so the
+        // unit-test path through a hand-rolled FakeDbConnection isn't enough
+        // to prove the production scenario.
+        var logged = (string)entry.GetValue("ConnectionString")!;
+        Assert.DoesNotContain("topsecret", logged, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_against_closed_sqlite_connection_emits_null_server_version()
+    {
+        var provider = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(builder => builder.AddProvider(provider));
+        var logger = factory.CreateLogger<DbConnectionLoggerIntegrationTests>();
+
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        // intentionally not opened
+
+        logger.LogDbConnection(connection);
+
+        var entry = Assert.Single(provider.Entries);
+        Assert.Null(entry.GetValue("ServerVersion"));
+        Assert.Equal(ConnectionState.Closed, entry.GetValue("State"));
+    }
+
+
+
+    [Fact]
+    public void LogDbConnection_respects_pipeline_minimum_level()
+    {
+        var provider = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Warning);
+            builder.AddProvider(provider);
+        });
+        var logger = factory.CreateLogger<DbConnectionLoggerIntegrationTests>();
+
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        // Default overload logs at Information; with min=Warning, nothing
+        // should reach the provider.
+        logger.LogDbConnection(connection);
+        Assert.Empty(provider.Entries);
+
+        // Explicit Warning should pass.
+        logger.LogDbConnection(connection, LogLevel.Warning);
+        Assert.Single(provider.Entries);
+    }
+}
+
+
+/// <summary>
+/// Minimal <see cref="ILoggerProvider"/> that captures every log entry as a
+/// structured payload. Keeps the integration tests free of any concrete sink
+/// (Console / Debug / Serilog / etc.) so they only assert what the library
+/// produces, not what a sink renders.
+/// </summary>
+internal sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    public List<CapturedEntry> Entries { get; } = new();
+
+    public ILogger CreateLogger(string categoryName) => new CapturingLogger(this);
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        private readonly CapturingLoggerProvider _provider;
+
+        public CapturingLogger(CapturingLoggerProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter)
+        {
+            var values = state as IReadOnlyList<KeyValuePair<string, object?>>;
+            _provider.Entries.Add(new CapturedEntry(logLevel, formatter(state, exception), values));
+        }
+    }
+
+    private sealed class NullScope : System.IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}
+
+
+internal sealed class CapturedEntry
+{
+    private readonly IReadOnlyList<KeyValuePair<string, object?>>? _values;
+
+    public CapturedEntry(LogLevel level, string message, IReadOnlyList<KeyValuePair<string, object?>>? values)
+    {
+        Level = level;
+        Message = message;
+        _values = values;
+    }
+
+    public LogLevel Level { get; }
+
+    public string Message { get; }
+
+    public object? GetValue(string name)
+    {
+        if (_values is null)
+        {
+            return null;
+        }
+
+        foreach (var kv in _values)
+        {
+            if (kv.Key == name)
+            {
+                return kv.Value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/Wolfgang.Extensions.Logging.Data.Tests.Integration.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/Wolfgang.Extensions.Logging.Data.Tests.Integration.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+
+    <!-- Real Microsoft.Extensions.Logging pipeline, not just Abstractions. -->
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+
+    <!-- Real DbConnection implementation for integration coverage. SQLite is
+         lightweight, in-process, and works across every TFM the integration
+         project targets, so the test doesn't need any external infrastructure. -->
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.Logging.Data\Wolfgang.Extensions.Logging.Data.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Stands up `tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/` exercising `LogDbConnection` against:

- A **real** `DbConnection` implementation (Microsoft.Data.Sqlite — lightweight, in-process, no external infrastructure required)
- A **real** `Microsoft.Extensions.Logging` pipeline via `LoggerFactory.Create` — not the hand-rolled `RecordingLogger` the unit tests use

Where the unit tests stub both ends, these tests prove the extension method works against the production .NET logging pipeline and a production ADO.NET provider — so a regression in either contract surfaces here without the unit-test fakes needing to track it.

## Scenarios

| Test | Asserts |
|---|---|
| `LogDbConnection_against_open_sqlite_connection_emits_a_structured_entry` | Open the connection, call `LogDbConnection`, verify the structured payload reaches the provider with the right `DataSource`, `State`, `ServerVersion`, `ConnectionType`. **Critically:** `Password=topsecret` must be redacted from the logged value — and this goes through `SqliteConnection.ConnectionString` (which normalizes keys) so the FakeDbConnection unit tests can't prove the production scenario. |
| `LogDbConnection_against_closed_sqlite_connection_emits_null_server_version` | `TryGetServerVersion` fallback asserted against the production `SqliteConnection` class rather than the fake. |
| `LogDbConnection_respects_pipeline_minimum_level` | `LoggerFactory` min level = `Warning` — default-overload call (Information) produces nothing; explicit Warning call reaches the provider. |

## Infrastructure

- **`CapturingLoggerProvider`** — minimal `ILoggerProvider` recording every entry as a structured payload, decoupled from any concrete sink so assertions focus on what the library produces.
- **`CapturedEntry`** — value holding Level + Message + named property list, with a `GetValue` helper mirroring the unit-test `LogEntry`.

## TFMs

`net8.0;net10.0`. Microsoft.Data.Sqlite drops support for net462–net6.0 in current versions, so the integration project is intentionally a narrower modern-runtime addition rather than a replacement for the unit project's wide TFM matrix.

## Issue mapping

- Closes #43 (testing: Add an integration test suite)

## Stacked on

Base: `vNext`. Seventh in the stack.