### PR TITLE
docfx.json: wire version-picker bootstrap + fix dashed app name (cosmetic but visible)

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -45,12 +45,12 @@
       "modern"
     ],
     "globalMetadata": {
-      "_appName": "Wolfgang.Extensions-Logging-Data",
-      "_appTitle": "Wolfgang.Extensions-Logging-Data Documentation",
+      "_appName": "Wolfgang.Extensions.Logging.Data",
+      "_appTitle": "Wolfgang.Extensions.Logging.Data Documentation",
       "_appLogoPath": "logo.svg",
       "_appFaviconPath": "favicon.svg",
       "_enableSearch": true,
-      "_appFooter": "Made with DocFX",
+      "_appFooter": "Made with DocFX <script>(function(){var r='/';if(window.location.hostname.endsWith('.github.io')){var s=window.location.pathname.split('/').filter(Boolean);if(s.length)r='/'+s[0]+'/';}var t=document.createElement('script');t.src=r+'public/version-picker.js';t.async=true;document.head.appendChild(t);})();</script>",
       "_disableSidebar": false,
       "_disableTocFilter": false,
       "_enableDarkMode": true,


### PR DESCRIPTION
## Summary

Two real docs-site bugs caught by auditing what the live gh-pages deploy actually renders vs the canonical pattern (DateTime-Extensions / ICollection-Extensions etc.).

## 1. Picker bootstrap was missing — dropdown didn't render

The canonical pattern lazy-loads `public/version-picker.js` via an inline `<script>` in DocFX's `globalMetadata._appFooter`. This repo's `docfx.json` had `_appFooter: "Made with DocFX"` with no script tag at all — so the picker JS file shipped into `_site/public/version-picker.js` but **never got loaded by any page**. The dropdown was invisible on every page of `chris-wolfgang.github.io/Extensions-Logging-Data/`.

Restored the canonical inline-bootstrap IIFE that:

- on `*.github.io` picks up the first non-empty pathname segment as the repo prefix (`/<repo>/public/version-picker.js`)
- elsewhere falls back to `/public/version-picker.js` so localhost / CNAME hosting also works

The script is byte-identical to the canonical version in DateTime-Extensions / D20-Dice / etc. — copy-pasted verbatim so it stays fleet-canonical.

## 2. `_appName` / `_appTitle` used the dashed package name

```diff
-      "_appName":  "Wolfgang.Extensions-Logging-Data",
-      "_appTitle": "Wolfgang.Extensions-Logging-Data Documentation",
+      "_appName":  "Wolfgang.Extensions.Logging.Data",
+      "_appTitle": "Wolfgang.Extensions.Logging.Data Documentation",
```

Same drift the D2 README rewrite caught. The dashed form doesn't match the actual NuGet package id (`Wolfgang.Extensions.Logging.Data`) — users on the docs site were seeing a navbar brand and browser tab title that refer to a package that doesn't exist on NuGet.

## What this PR does *not* fix

- `_baseUrl` is currently `Chris-Wolfgang.github.io/Extensions-Logging-Data/` (the github.io repo name, not the package id). That's the right value — the docs site lives at the repo URL, not the package URL.

## Stacked on

Base: `vNext`. Eleventh in the docs/canonical-sync stack.

`docfx_project/docfx.json` is an unprotected file, so this PR is a normal merge, no admin-bypass needed.