### PR TITLE
Fix NU1605: align M.E.L.Abstractions/Logging to 10.0.8 across test + benchmark projects

### DIFF
--- a/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/Wolfgang.Extensions.Logging.Data.Tests.Integration.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/Wolfgang.Extensions.Logging.Data.Tests.Integration.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
 
     <!-- Real Microsoft.Extensions.Logging pipeline, not just Abstractions. -->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
 
     <!-- Real DbConnection implementation for integration coverage. SQLite is
          lightweight, in-process, and works across every TFM the integration

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Unblocks PR #72 (and the release). vNext's src csproj pins `Microsoft.Extensions.Logging.Abstractions` 10.0.8 but the test, benchmark, and integration projects still pinned 10.0.7, producing NU1605 package-downgrade errors under TreatWarningsAsErrors.

- tests/…Tests.Unit: M.E.L.Abstractions 10.0.7 → 10.0.8
- benchmarks/…Benchmarks: M.E.L.Abstractions 10.0.7 → 10.0.8
- tests/…Tests.Integration: M.E.Logging 10.0.7 → 10.0.8 (pulls Abstractions transitively)

All four projects now agree on 10.0.8.

Stacked on `vNext`; merge then the Stage 1 Linux + CodeQL checks on PR #72 should both clear (CodeQL was failing because the build failed).