### PR TITLE
Release v0.1.1 prep: CHANGELOG entry + PublicAPI baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.1.1] - 2026-06-12
+
+Canonical maintenance round + binding-stability fix. No public API or
+runtime behavior change vs v0.1.0.
+
+### Added
+
+- **D8** — docs-site version-picker dropdown + purple-W logo/favicon,
+  with the picker bootstrap wired into `docfx.json` so the dropdown
+  renders on the published site; `verify-docs-build` job in
+  `release.yaml` runs DocFX before the NuGet push so a docs build
+  failure blocks the package from shipping.
+- **A1** — `PublicApiAnalyzers` with a baselined public surface
+  (`PublicAPI.Shipped.txt`), so breaking-change detection is active
+  from this release forward.
+- **CI3** — canonical NuGet package metadata: `Authors`, `Copyright`,
+  `RepositoryType`, SourceLink, snupkg symbol packages, deterministic
+  CI build flag, and `EmbedUntrackedSources` hoisted to
+  `Directory.Build.props`.
+- **T1** — coverage report published to the docs site.
+- **T3** — Stryker mutation-testing workflow (`stryker.yaml`).
+- **S1** — CodeQL `security-extended` query pack.
+- **D6** — `versions.json` preservation guard on the docs deploy.
+- **P1/P2** — BenchmarkDotNet baseline project (`LogDbConnection`
+  fast-path / full-work / explicit-level scenarios) with a
+  `benchmarks.yaml` workflow that publishes results to the gh-pages
+  chart.
+- An integration test suite exercising `LogDbConnection` against a
+  real `Microsoft.Data.Sqlite` connection and a real
+  `Microsoft.Extensions.Logging` pipeline, plus globalization
+  (tr-TR/de-DE/zh-CN/ar-SA/ja-JP) invariance and allocation-free
+  hot-path verification tests.
+
+### Changed
+
+- **C1** — fleet-wide template-drift sync: workflow files (`pr.yaml`,
+  `release.yaml`, `docfx.yaml`, `codeql.yaml`,
+  `build-all-versions.yaml`, `stryker.yaml`), `.editorconfig`,
+  `BannedSymbols.txt`, `Directory.Build.props`, and per-context
+  `tests/Directory.Build.props` consolidated to the canonical baseline.
+- **Nullable** — `<Nullable>enable</Nullable>` consolidated into
+  `Directory.Build.props` (was per-csproj).
+- **CI2** — Dependabot `github-actions` ecosystem added; the
+  `dotnet-dependencies` group bumped `Microsoft.Extensions.Logging`/
+  `.Abstractions` to 10.0.9 across all projects.
+- **README** — rewritten for accuracy: corrected package id
+  (`Wolfgang.Extensions.Logging.Data`, dotted), canonical badge
+  collection, accurate Quick Start + Features + Target Frameworks
+  matching the actual public surface.
+
+### Fixed
+
+- **C4** — pinned explicit `<AssemblyVersion>1.0.0.0</AssemblyVersion>`
+  and a prerelease-safe `<FileVersion>` to the src csproj. Without an
+  explicit pin, SDK-derived `AssemblyVersion` would change on every
+  minor/patch release, breaking `net462` .NET Framework consumers
+  without a binding redirect.
+
+## [0.1.0] - 2026-05-02
+
+Initial release.
+
+### Added
+
+- `ILogger.LogDbConnection(DbConnection)` — logs a single structured
+  entry describing a `DbConnection` at `LogLevel.Information`.
+- `ILogger.LogDbConnection(DbConnection, LogLevel)` — same, at a
+  caller-specified level.
+- Built-in credential redaction: the `Password` / `Pwd` keys are
+  stripped from the logged connection string (case-insensitive) so
+  credentials are never written to the log; all other keys, including
+  the user name, are preserved.
+- Structured-logging output (`ConnectionType`, `Database`,
+  `DataSource`, `ServerVersion`, `State`, `ConnectionTimeout`,
+  `ConnectionString`) and an `IsEnabled` short-circuit so the
+  redaction work is skipped when the log level isn't enabled.
+- Multi-targeting: `net462`, `netstandard2.0`, `netstandard2.1`,
+  `net10.0`.
+
+[Unreleased]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/releases/tag/v0.1.0

--- a/src/Wolfgang.Extensions.Logging.Data/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Extensions.Logging.Data/PublicAPI.Shipped.txt
@@ -1,0 +1,4 @@
+#nullable enable
+static Wolfgang.Extensions.Logging.Data.DbConnectionLoggerExtensions.LogDbConnection(this Microsoft.Extensions.Logging.ILogger logger, System.Data.Common.DbConnection connection) -> void
+static Wolfgang.Extensions.Logging.Data.DbConnectionLoggerExtensions.LogDbConnection(this Microsoft.Extensions.Logging.ILogger logger, System.Data.Common.DbConnection connection, Microsoft.Extensions.Logging.LogLevel level) -> void
+Wolfgang.Extensions.Logging.Data.DbConnectionLoggerExtensions

--- a/src/Wolfgang.Extensions.Logging.Data/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.Logging.Data/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable


### PR DESCRIPTION
## Summary

Final pre-release prep for **v0.1.1** — the two gaps identified in the release-readiness check.

## Changes (3 files, all unprotected)

### 1. `CHANGELOG.md`
The CHANGELOG had no version sections at all — just the empty `[Unreleased]` template. Added:
- **`[0.1.1]`** entry documenting the canonical maintenance round (D8 picker/logo, A1 PublicApiAnalyzers, CI3 metadata, T1/T3, S1, D6, P1/P2 benchmarks, integration + globalization + allocation tests, C1 drift sync, CI2 dependabot, README rewrite, C4 AssemblyVersion pin)
- **`[0.1.0]`** backfill (initial release — the two `LogDbConnection` overloads + credential redaction + structured logging + multi-targeting)
- compare-link footer

### 2. `src/Wolfgang.Extensions.Logging.Data/PublicAPI.Shipped.txt` (new)
Baselines the public surface so **A1 PublicApiAnalyzers actually performs breaking-change detection from v0.1.1 forward** (the analyzer was inert — `Directory.Build.props` referenced the files conditionally but they didn't exist):

```
#nullable enable
static …DbConnectionLoggerExtensions.LogDbConnection(this ILogger, DbConnection) -> void
static …DbConnectionLoggerExtensions.LogDbConnection(this ILogger, DbConnection, LogLevel) -> void
Wolfgang.Extensions.Logging.Data.DbConnectionLoggerExtensions
```

### 3. `src/Wolfgang.Extensions.Logging.Data/PublicAPI.Unshipped.txt` (new)
Seeded with the `#nullable enable` header (empty baseline — nothing pending).

## Verification (local)

- `dotnet build -c Release` — **0 warnings, 0 errors**, no RS0016 (missing entry) / RS0017 (entry for absent symbol) from the now-active analyzer
- Full TFM test matrix — **51 unit + 4 integration pass** (net462 → net10.0)

## Next

Once this merges to `main`, the repo is release-ready:
`gh release create v0.1.1 --target main` → tags + publishes the Release object → `release.yaml` fires (pack → NuGet push → docs deploy).