### PR TITLE
docfx.json: add favicon.ico + apple-touch-icon.png to resource.files

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -34,13 +34,14 @@
         "files": [
           "logo.svg",
           "favicon.svg",
+          "apple-touch-icon.png",
+          "favicon.ico",
           "images/**",
           "public/**",
           "versions.json"
         ]
       }
     ],
-
     "output": "_site",
     "template": [
       "default",
@@ -62,4 +63,3 @@
     }
   }
 }
-


### PR DESCRIPTION
## Summary

The earlier favicon fanout added these assets to `docfx_project/` but the docfx.json patch on this repo only listed `favicon.svg` in `build.resource.files`. The `.ico` and `apple-touch-icon.png` files are on disk but never get copied into `_site/` — so the apple-touch endpoint 404s on gh-pages.

This PR adds them to the resource list. No other changes.