### PR TITLE
Normalize PublicAPI.Shipped.txt to canonical nullable-annotated format

### DIFF
--- a/src/Wolfgang.Extensions.Logging.Data/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Extensions.Logging.Data/PublicAPI.Shipped.txt
@@ -1,4 +1,4 @@
 #nullable enable
-static Wolfgang.Extensions.Logging.Data.DbConnectionLoggerExtensions.LogDbConnection(this Microsoft.Extensions.Logging.ILogger logger, System.Data.Common.DbConnection connection) -> void
-static Wolfgang.Extensions.Logging.Data.DbConnectionLoggerExtensions.LogDbConnection(this Microsoft.Extensions.Logging.ILogger logger, System.Data.Common.DbConnection connection, Microsoft.Extensions.Logging.LogLevel level) -> void
+static Wolfgang.Extensions.Logging.Data.DbConnectionLoggerExtensions.LogDbConnection(this Microsoft.Extensions.Logging.ILogger! logger, System.Data.Common.DbConnection! connection) -> void
+static Wolfgang.Extensions.Logging.Data.DbConnectionLoggerExtensions.LogDbConnection(this Microsoft.Extensions.Logging.ILogger! logger, System.Data.Common.DbConnection! connection, Microsoft.Extensions.Logging.LogLevel level) -> void
 Wolfgang.Extensions.Logging.Data.DbConnectionLoggerExtensions


### PR DESCRIPTION
## Summary

The v0.1.1 `PublicAPI.Shipped.txt` recorded the two `LogDbConnection` entries in the **nullable-oblivious** form (no `!`/`?` markers):

```diff
-static …LogDbConnection(this Microsoft.Extensions.Logging.ILogger logger, System.Data.Common.DbConnection connection) -> void
+static …LogDbConnection(this Microsoft.Extensions.Logging.ILogger! logger, System.Data.Common.DbConnection! connection) -> void
```

The PublicApiAnalyzers canonical format — used across the fleet (ICollection/IEnumerable/etc.) **and by this repo's own `Unshipped.txt` `DbCommandLoggerExtensions` entries** (added in #131) — annotates non-null reference types with `!` and nullable with `?`. Both forms compile, but having both within one project is inconsistent.

## Change

Add `!` to the `ILogger` and `DbConnection` reference-type parameters. `LogLevel` is a value type, so no marker.

## Verification

`dotnet build -c Release` clean — no RS0016 (missing) / RS0017 (mismatch) from the now-active analyzer. Unprotected file (`src/…/PublicAPI.Shipped.txt`), so a normal merge — no admin-bypass.

## Context

Follow-up to the latent inconsistency flagged during #3 (`LogCommandText`), where the analyzer's required `!`-annotated format was discovered via RS0017.