### PR TITLE
Fix NU1903: bump SQLitePCLRaw off vulnerable 2.1.11

### DIFF
--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/Wolfgang.Extensions.Logging.Data.Tests.Integration.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/Wolfgang.Extensions.Logging.Data.Tests.Integration.csproj
@@ -22,6 +22,11 @@
          lightweight, in-process, and works across every TFM the integration
          project targets, so the test doesn't need any external infrastructure. -->
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <!-- Override the transitive SQLitePCLRaw chain. Microsoft.Data.Sqlite 10.0.9
+         pins 2.1.11, which carries GHSA-2m69-gcr7-jv3q with no patched 2.1.x
+         release. 3.0.x (bundle) / 3.50.x (native lib) is outside the advisory's affected range (<= 2.1.11)
+         and is API-compatible with Microsoft.Data.Sqlite's provider contract. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem
The integration project's transitive `SQLitePCLRaw.lib.e_sqlite3 2.1.11` (pulled by `Microsoft.Data.Sqlite 10.0.9`) carries **GHSA-2m69-gcr7-jv3q** (high severity). There is **no patched 2.1.x release** — the affected range is `<= 2.1.11`. Under `TreatWarningsAsErrors` this fails restore/build with `error NU1903`, red-failing CI on every PR.

## Fix
Pin `SQLitePCLRaw.bundle_e_sqlite3` to `3.0.3` in the integration csproj. The 3.x chain pulls the patched native `lib.e_sqlite3 3.50.3`, which is outside the advisory's affected range and API-compatible with Microsoft.Data.Sqlite's provider contract.

This is a **test-only** project (in-memory SQLite, trusted SQL) — the dependency does not ship in any package.

## Verification (local)
- Clean restore — no `NU1903`, no `NU1605`.
- Integration tests **4/4 pass on both net8.0 and net10.0** (native binary loads + executes).

Merging this first unblocks CI for all open PRs (incl. #139).