### PR TITLE
Add EntityFramework6 companion package (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `excludedParameterNames`, and both). `DBNull` parameter values render as
   `null`. This is the bridge the forthcoming EF6 interceptor companion
   package consumes to log commands without per-query call sites. (#66)
+- **New companion package `Wolfgang.Extensions.Logging.Data.EntityFramework6`** —
+  passive structured logging of every Entity Framework 6 command, connection,
+  and transaction event via the EF6 interceptor pipeline. A single startup call,
+  `EntityFramework6Logging.AddLoggingInterceptors(logger, excludedParameterNames,
+  level)`, wires command/connection/transaction interceptors so every
+  `DbContext` in the process is logged with zero per-query call sites. Commands
+  delegate to `LogDbCommand` (parameter snapshot + redaction), connections to
+  `LogDbConnection` (connection-string redaction), and failures are surfaced at
+  `LogLevel.Error` from the interception context. `DbInterception.Add` is
+  process-global and not idempotent, so registration is guarded against
+  double-registration per logger instance. Targets `net462;net48;netstandard2.1`.
+  (#66)
 
 ### Changed
 

--- a/Extensions-Logging-Data.slnx
+++ b/Extensions-Logging-Data.slnx
@@ -47,10 +47,12 @@
   <Folder Name="/examples/" />
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj" />
+    <Project Path="src/Wolfgang.Extensions.Logging.Data.EntityFramework6/Wolfgang.Extensions.Logging.Data.EntityFramework6.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/Wolfgang.Extensions.Logging.Data.Tests.Integration.csproj" />
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj" />
+    <Project Path="tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.csproj" />
   </Folder>
 </Solution>
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,34 @@ logger.LogDbConnection(connection, LogLevel.Debug);
 | **`IsEnabled(level)` short-circuit** — work is skipped if the log level isn't enabled, so the redaction / `DbConnectionStringBuilder` parse only runs when the entry will actually be written | (built-in) |
 | **Null-safe** — throws `ArgumentNullException` (not `NullReferenceException`) when `logger` or `connection` is `null` | (every overload) |
 
-**Roadmap:** `DbCommand` and additional `System.Data` types are next on the surface. The library is intentionally narrow today and grows one type at a time as needed.
+`DbCommand` logging is also available via `ILogger.LogCommandText(...)` (command text + parameter snapshot with opt-in redaction) and `ILogger.LogDbCommand(DbCommand, ...)` (logs a live command directly). The library is intentionally narrow and grows one type at a time as needed.
+
+---
+
+## 🪵 Entity Framework 6 companion
+
+The optional **`Wolfgang.Extensions.Logging.Data.EntityFramework6`** package wires these extension methods into the EF6 interceptor pipeline so a legacy EF6 app logs *every* command, connection, and transaction event with **no per-query call sites**. Register once at startup:
+
+```csharp
+// At application startup, before any DbContext is used:
+EntityFramework6Logging.AddLoggingInterceptors(
+    logger,
+    excludedParameterNames: new[] { "password" },   // optional — redacted in logged commands
+    level: LogLevel.Information);                    // optional — defaults to Information
+```
+
+From then on, every `DbContext` in the process logs:
+
+- **Commands** — text + parameter snapshot (redacted), via `LogDbCommand`.
+- **Connections** — open/close lifecycle, with connection-string redaction, via `LogDbConnection`.
+- **Transactions** — commit / rollback.
+- **Failures** — surfaced at `LogLevel.Error` from the EF6 interception context.
+
+`DbInterception.Add` is process-global and not idempotent, so `AddLoggingInterceptors` is a no-op if called again with the same `logger` instance. Targets `net462; net48; netstandard2.1`.
+
+```bash
+dotnet add package Wolfgang.Extensions.Logging.Data.EntityFramework6
+```
 
 ---
 

--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/EntityFramework6Logging.cs
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/EntityFramework6Logging.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Entity.Infrastructure.Interception;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data.EntityFramework6;
+
+/// <summary>
+/// One-call registration of passive EF6 logging. Calling <c>AddLoggingInterceptors</c>
+/// once at startup wires command, connection, and transaction interceptors into the
+/// process-global EF6 interception pipeline, so every <c>DbContext</c> in the process
+/// logs its activity with no per-query call sites.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="DbInterception.Add"/> is process-global and not idempotent — adding the same
+/// interceptor twice doubles every log entry. To make the common "call it once per logger"
+/// pattern safe, this type keeps a static record of the loggers it has already registered
+/// and treats a repeat registration of the same logger instance as a no-op.
+/// </para>
+/// </remarks>
+public static class EntityFramework6Logging
+{
+    private static readonly object Gate = new object();
+
+    // Identity comparison: the same logger instance must not be registered twice, but two
+    // distinct loggers (e.g. different categories) are legitimately allowed to both log.
+    private static readonly HashSet<ILogger> RegisteredLoggers =
+        new HashSet<ILogger>(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// Registers command, connection, and transaction logging interceptors for the given
+    /// <paramref name="logger"/> into the EF6 interception pipeline. Safe to call more than
+    /// once with the same <paramref name="logger"/> instance — repeat calls are a no-op.
+    /// </summary>
+    /// <param name="logger">The logger every EF6 event is written to.</param>
+    /// <param name="excludedParameterNames">
+    /// Optional parameter names whose values are redacted in logged commands. Matching is
+    /// case-insensitive and ADO.NET-prefix-tolerant. When <see langword="null"/>, nothing is
+    /// redacted.
+    /// </param>
+    /// <param name="level">The level every non-error event is logged at. Defaults to <c>LogLevel.Information</c>.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="logger"/> is <see langword="null"/>.</exception>
+    public static void AddLoggingInterceptors(ILogger logger, IEnumerable<string>? excludedParameterNames = null, LogLevel level = LogLevel.Information)
+    {
+        AddLoggingInterceptors(logger, excludedParameterNames, level, DbInterception.Add);
+    }
+
+    /// <summary>
+    /// Registration seam used by the public overload and by tests. The <paramref name="register"/>
+    /// delegate is <see cref="DbInterception.Add"/> in production; tests supply a recording
+    /// delegate so they can assert what was registered without mutating EF6's process-global
+    /// interception state.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="logger"/> is <see langword="null"/>.</exception>
+    internal static void AddLoggingInterceptors(ILogger logger, IEnumerable<string>? excludedParameterNames, LogLevel level, Action<IDbInterceptor> register)
+    {
+        if (logger is null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
+        var excluded = excludedParameterNames ?? Array.Empty<string>();
+
+        lock (Gate)
+        {
+            if (!RegisteredLoggers.Add(logger))
+            {
+                return;
+            }
+
+            register(new LoggingCommandInterceptor(logger, excluded, level));
+            register(new LoggingConnectionInterceptor(logger, level));
+            register(new LoggingTransactionInterceptor(logger, level));
+        }
+    }
+
+    /// <summary>
+    /// Reference-identity comparer so the registration set distinguishes logger instances by
+    /// identity rather than by any overridden <see cref="object.Equals(object)"/>.
+    /// </summary>
+    private sealed class ReferenceEqualityComparer : IEqualityComparer<ILogger>
+    {
+        internal static readonly ReferenceEqualityComparer Instance = new ReferenceEqualityComparer();
+
+        public bool Equals(ILogger? x, ILogger? y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(ILogger obj) => RuntimeHelpers.GetHashCode(obj);
+    }
+}

--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/LoggingCommandInterceptor.cs
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/LoggingCommandInterceptor.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.Entity.Infrastructure.Interception;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data;
+
+namespace Wolfgang.Extensions.Logging.Data.EntityFramework6;
+
+/// <summary>
+/// EF6 <see cref="IDbCommandInterceptor"/> that logs every command the EF6 pipeline
+/// executes. The <c>*Executing</c> callbacks fire before the command runs and are
+/// routed to <c>ILogger.LogDbCommand</c>;
+/// the <c>*Executed</c> callbacks log a failure at <c>LogLevel.Error</c> when the
+/// interception context carries an exception (EF6 surfaces the exception on the context
+/// rather than throwing at the interceptor).
+/// </summary>
+internal sealed class LoggingCommandInterceptor : IDbCommandInterceptor
+{
+    private readonly ILogger _logger;
+    private readonly IEnumerable<string> _excludedParameterNames;
+    private readonly LogLevel _level;
+
+    public LoggingCommandInterceptor(ILogger logger, IEnumerable<string> excludedParameterNames, LogLevel level)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _excludedParameterNames = excludedParameterNames ?? Array.Empty<string>();
+        _level = level;
+    }
+
+    public void NonQueryExecuting(DbCommand command, DbCommandInterceptionContext<int> interceptionContext)
+    {
+        LogExecuting(command);
+    }
+
+    public void NonQueryExecuted(DbCommand command, DbCommandInterceptionContext<int> interceptionContext)
+    {
+        LogFailure(command, interceptionContext);
+    }
+
+    public void ReaderExecuting(DbCommand command, DbCommandInterceptionContext<DbDataReader> interceptionContext)
+    {
+        LogExecuting(command);
+    }
+
+    public void ReaderExecuted(DbCommand command, DbCommandInterceptionContext<DbDataReader> interceptionContext)
+    {
+        LogFailure(command, interceptionContext);
+    }
+
+    public void ScalarExecuting(DbCommand command, DbCommandInterceptionContext<object> interceptionContext)
+    {
+        LogExecuting(command);
+    }
+
+    public void ScalarExecuted(DbCommand command, DbCommandInterceptionContext<object> interceptionContext)
+    {
+        LogFailure(command, interceptionContext);
+    }
+
+    private void LogExecuting(DbCommand command)
+    {
+        if (command is null)
+        {
+            return;
+        }
+
+        _logger.LogDbCommand(command, _excludedParameterNames, _level);
+    }
+
+    private void LogFailure<TResult>(DbCommand command, DbCommandInterceptionContext<TResult> interceptionContext)
+    {
+        if (command is null || interceptionContext?.Exception is null)
+        {
+            return;
+        }
+
+        _logger.Log(LogLevel.Error, interceptionContext.Exception, "EF6 command failed: {CommandText}", command.CommandText);
+    }
+}

--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/LoggingConnectionInterceptor.cs
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/LoggingConnectionInterceptor.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Data.Entity.Infrastructure.Interception;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data;
+
+namespace Wolfgang.Extensions.Logging.Data.EntityFramework6;
+
+/// <summary>
+/// EF6 <see cref="IDbConnectionInterceptor"/> that logs the connection lifecycle. The rich,
+/// redacted connection entry is written on <see cref="Opening"/> via
+/// <c>ILogger.LogDbConnection</c>;
+/// open/close transitions are logged at the configured level and a failed open/close is logged
+/// at <c>LogLevel.Error</c> from the interception context's exception. The many
+/// property-getter / setter callbacks EF6 fires (<c>DataSourceGetting</c>, <c>StateGot</c>, …)
+/// are intentionally no-ops — logging them would bury the meaningful events in noise.
+/// </summary>
+internal sealed class LoggingConnectionInterceptor : IDbConnectionInterceptor
+{
+    private readonly ILogger _logger;
+    private readonly LogLevel _level;
+
+    public LoggingConnectionInterceptor(ILogger logger, LogLevel level)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _level = level;
+    }
+
+    public void Opening(DbConnection connection, DbConnectionInterceptionContext interceptionContext)
+    {
+        if (connection != null)
+        {
+            _logger.LogDbConnection(connection, _level);
+        }
+    }
+
+    public void Opened(DbConnection connection, DbConnectionInterceptionContext interceptionContext)
+    {
+        if (!LogErrorIfFailed(interceptionContext, "EF6 connection open failed"))
+        {
+            _logger.Log(_level, "EF6 connection opened");
+        }
+    }
+
+    public void Closing(DbConnection connection, DbConnectionInterceptionContext interceptionContext)
+    {
+    }
+
+    public void Closed(DbConnection connection, DbConnectionInterceptionContext interceptionContext)
+    {
+        if (!LogErrorIfFailed(interceptionContext, "EF6 connection close failed"))
+        {
+            _logger.Log(_level, "EF6 connection closed");
+        }
+    }
+
+    private bool LogErrorIfFailed(DbConnectionInterceptionContext interceptionContext, string message)
+    {
+        if (interceptionContext?.Exception is null)
+        {
+            return false;
+        }
+
+        _logger.Log(LogLevel.Error, interceptionContext.Exception, message);
+        return true;
+    }
+
+    // The remaining callbacks are deliberate no-ops: transaction lifecycle is handled by
+    // LoggingTransactionInterceptor, and the property accessor callbacks are too noisy for
+    // passive logging.
+
+    public void BeganTransaction(DbConnection connection, BeginTransactionInterceptionContext interceptionContext)
+    {
+    }
+
+    public void BeginningTransaction(DbConnection connection, BeginTransactionInterceptionContext interceptionContext)
+    {
+    }
+
+    public void ConnectionStringGetting(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext)
+    {
+    }
+
+    public void ConnectionStringGot(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext)
+    {
+    }
+
+    public void ConnectionStringSetting(DbConnection connection, DbConnectionPropertyInterceptionContext<string> interceptionContext)
+    {
+    }
+
+    public void ConnectionStringSet(DbConnection connection, DbConnectionPropertyInterceptionContext<string> interceptionContext)
+    {
+    }
+
+    public void ConnectionTimeoutGetting(DbConnection connection, DbConnectionInterceptionContext<int> interceptionContext)
+    {
+    }
+
+    public void ConnectionTimeoutGot(DbConnection connection, DbConnectionInterceptionContext<int> interceptionContext)
+    {
+    }
+
+    public void DatabaseGetting(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext)
+    {
+    }
+
+    public void DatabaseGot(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext)
+    {
+    }
+
+    public void DataSourceGetting(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext)
+    {
+    }
+
+    public void DataSourceGot(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext)
+    {
+    }
+
+    public void Disposing(DbConnection connection, DbConnectionInterceptionContext interceptionContext)
+    {
+    }
+
+    public void Disposed(DbConnection connection, DbConnectionInterceptionContext interceptionContext)
+    {
+    }
+
+    public void EnlistedTransaction(DbConnection connection, EnlistTransactionInterceptionContext interceptionContext)
+    {
+    }
+
+    public void EnlistingTransaction(DbConnection connection, EnlistTransactionInterceptionContext interceptionContext)
+    {
+    }
+
+    public void ServerVersionGetting(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext)
+    {
+    }
+
+    public void ServerVersionGot(DbConnection connection, DbConnectionInterceptionContext<string> interceptionContext)
+    {
+    }
+
+    public void StateGetting(DbConnection connection, DbConnectionInterceptionContext<ConnectionState> interceptionContext)
+    {
+    }
+
+    public void StateGot(DbConnection connection, DbConnectionInterceptionContext<ConnectionState> interceptionContext)
+    {
+    }
+}

--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/LoggingTransactionInterceptor.cs
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/LoggingTransactionInterceptor.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Data.Entity.Infrastructure.Interception;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data.EntityFramework6;
+
+/// <summary>
+/// EF6 <see cref="IDbTransactionInterceptor"/> that logs transaction commit and rollback at
+/// the configured level, and logs a failed commit/rollback at <c>LogLevel.Error</c>
+/// from the interception context's exception. The connection / isolation-level / dispose
+/// accessor callbacks are intentional no-ops.
+/// </summary>
+internal sealed class LoggingTransactionInterceptor : IDbTransactionInterceptor
+{
+    private readonly ILogger _logger;
+    private readonly LogLevel _level;
+
+    public LoggingTransactionInterceptor(ILogger logger, LogLevel level)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _level = level;
+    }
+
+    public void Committing(DbTransaction transaction, DbTransactionInterceptionContext interceptionContext)
+    {
+        _logger.Log(_level, "EF6 transaction committing");
+    }
+
+    public void Committed(DbTransaction transaction, DbTransactionInterceptionContext interceptionContext)
+    {
+        if (!LogErrorIfFailed(interceptionContext, "EF6 transaction commit failed"))
+        {
+            _logger.Log(_level, "EF6 transaction committed");
+        }
+    }
+
+    public void RollingBack(DbTransaction transaction, DbTransactionInterceptionContext interceptionContext)
+    {
+        _logger.Log(_level, "EF6 transaction rolling back");
+    }
+
+    public void RolledBack(DbTransaction transaction, DbTransactionInterceptionContext interceptionContext)
+    {
+        if (!LogErrorIfFailed(interceptionContext, "EF6 transaction rollback failed"))
+        {
+            _logger.Log(_level, "EF6 transaction rolled back");
+        }
+    }
+
+    private bool LogErrorIfFailed(DbTransactionInterceptionContext interceptionContext, string message)
+    {
+        if (interceptionContext?.Exception is null)
+        {
+            return false;
+        }
+
+        _logger.Log(LogLevel.Error, interceptionContext.Exception, message);
+        return true;
+    }
+
+    // Deliberate no-ops — accessor callbacks carry no value for passive logging.
+
+    public void ConnectionGetting(DbTransaction transaction, DbTransactionInterceptionContext<DbConnection> interceptionContext)
+    {
+    }
+
+    public void ConnectionGot(DbTransaction transaction, DbTransactionInterceptionContext<DbConnection> interceptionContext)
+    {
+    }
+
+    public void Disposing(DbTransaction transaction, DbTransactionInterceptionContext interceptionContext)
+    {
+    }
+
+    public void Disposed(DbTransaction transaction, DbTransactionInterceptionContext interceptionContext)
+    {
+    }
+
+    public void IsolationLevelGetting(DbTransaction transaction, DbTransactionInterceptionContext<IsolationLevel> interceptionContext)
+    {
+    }
+
+    public void IsolationLevelGot(DbTransaction transaction, DbTransactionInterceptionContext<IsolationLevel> interceptionContext)
+    {
+    }
+}

--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/Properties/AssemblyInfo.cs
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit")]

--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+#nullable enable
+static Wolfgang.Extensions.Logging.Data.EntityFramework6.EntityFramework6Logging.AddLoggingInterceptors(Microsoft.Extensions.Logging.ILogger! logger, System.Collections.Generic.IEnumerable<string!>? excludedParameterNames = null, Microsoft.Extensions.Logging.LogLevel level = Microsoft.Extensions.Logging.LogLevel.Information) -> void
+Wolfgang.Extensions.Logging.Data.EntityFramework6.EntityFramework6Logging

--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/Wolfgang.Extensions.Logging.Data.EntityFramework6.csproj
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/Wolfgang.Extensions.Logging.Data.EntityFramework6.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net462;net48;netstandard2.1</TargetFrameworks>
+		<LangVersion>latest</LangVersion>
+		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+		<Version>0.1.1</Version>
+		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+		     do not need to recompile / add binding redirects on every minor/patch
+		     bump. Bump only on a deliberate breaking API change. FileVersion +
+		     InformationalVersion (the latter auto-derived from <Version>) carry
+		     the actual release version. -->
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
+		<Title>$(AssemblyName)</Title>
+		<Description>Passive structured logging of every Entity Framework 6 command, connection, and transaction event via the EF6 interceptor pipeline. Register once at startup with AddLoggingInterceptors; delegates to Wolfgang.Extensions.Logging.Data for rendering and secret redaction.</Description>
+		<PackageProjectUrl>https://github.com/Chris-Wolfgang/Extensions-Logging-Data</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/Chris-Wolfgang/Extensions-Logging-Data.git</RepositoryUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+		<PackageTags>logging;entityframework;ef6;interceptor;structured-logging;dbcommand;diagnostics</PackageTags>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<SignAssembly>False</SignAssembly>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Wolfgang.Extensions.Logging.Data\Wolfgang.Extensions.Logging.Data.csproj" />
+		<PackageReference Include="EntityFramework" Version="6.5.2" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+	</ItemGroup>
+</Project>

--- a/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/EntityFramework6LoggingTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/EntityFramework6LoggingTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Entity.Infrastructure.Interception;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit;
+
+public class EntityFramework6LoggingTests
+{
+    [Fact]
+    public void AddLoggingInterceptors_when_logger_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => EntityFramework6Logging.AddLoggingInterceptors(null!, null, LogLevel.Information, _ => { })
+        );
+    }
+
+
+
+    [Fact]
+    public void AddLoggingInterceptors_registers_command_connection_and_transaction_interceptors()
+    {
+        var logger = new RecordingLogger();
+        var registered = new List<IDbInterceptor>();
+
+        EntityFramework6Logging.AddLoggingInterceptors(logger, null, LogLevel.Information, registered.Add);
+
+        Assert.Collection
+        (
+            registered,
+            i => Assert.IsType<LoggingCommandInterceptor>(i),
+            i => Assert.IsType<LoggingConnectionInterceptor>(i),
+            i => Assert.IsType<LoggingTransactionInterceptor>(i)
+        );
+    }
+
+
+
+    [Fact]
+    public void AddLoggingInterceptors_when_called_twice_with_same_logger_registers_once()
+    {
+        var logger = new RecordingLogger();
+        var registered = new List<IDbInterceptor>();
+
+        EntityFramework6Logging.AddLoggingInterceptors(logger, null, LogLevel.Information, registered.Add);
+        EntityFramework6Logging.AddLoggingInterceptors(logger, null, LogLevel.Information, registered.Add);
+
+        Assert.Equal(3, registered.Count);
+    }
+
+
+
+    [Fact]
+    public void AddLoggingInterceptors_with_distinct_loggers_registers_each()
+    {
+        var registered = new List<IDbInterceptor>();
+
+        EntityFramework6Logging.AddLoggingInterceptors(new RecordingLogger(), null, LogLevel.Information, registered.Add);
+        EntityFramework6Logging.AddLoggingInterceptors(new RecordingLogger(), null, LogLevel.Information, registered.Add);
+
+        Assert.Equal(6, registered.Count);
+    }
+
+
+
+    [Fact]
+    public void AddLoggingInterceptors_public_overload_registers_into_EF6_without_throwing()
+    {
+        // Exercises the real DbInterception.Add path. The interceptors register into EF6's
+        // process-global pipeline but never fire (no DbContext runs in a unit test), and a
+        // repeat call with the same logger is the documented no-op.
+        var logger = new RecordingLogger();
+
+        EntityFramework6Logging.AddLoggingInterceptors(logger);
+        EntityFramework6Logging.AddLoggingInterceptors(logger, new[] { "password" }, LogLevel.Debug);
+
+        Assert.Empty(logger.Entries);
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/LoggingCommandInterceptorTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/LoggingCommandInterceptorTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Data.Entity.Infrastructure.Interception;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit;
+
+public class LoggingCommandInterceptorTests
+{
+    private static FakeDbCommand SampleCommand()
+    {
+        var command = new FakeDbCommand { CommandText = "SELECT * FROM Users WHERE Id = @id" };
+        command.AddParameter("@id", 1);
+        command.AddParameter("@password", "hunter2");
+        return command;
+    }
+
+
+
+    [Fact]
+    public void NonQueryExecuting_logs_the_command_at_the_configured_level()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingCommandInterceptor(logger, Array.Empty<string>(), LogLevel.Debug);
+
+        sut.NonQueryExecuting(SampleCommand(), new DbCommandInterceptionContext<int>());
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Debug, entry.Level);
+        Assert.Equal("SELECT * FROM Users WHERE Id = @id", entry.GetValue("CommandText"));
+    }
+
+
+
+    [Fact]
+    public void ReaderExecuting_logs_the_command()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingCommandInterceptor(logger, Array.Empty<string>(), LogLevel.Information);
+
+        sut.ReaderExecuting(SampleCommand(), new DbCommandInterceptionContext<System.Data.Common.DbDataReader>());
+
+        Assert.Single(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void ScalarExecuting_logs_the_command()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingCommandInterceptor(logger, Array.Empty<string>(), LogLevel.Information);
+
+        sut.ScalarExecuting(SampleCommand(), new DbCommandInterceptionContext<object>());
+
+        Assert.Single(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void Executing_redacts_excluded_parameter_values()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingCommandInterceptor(logger, new[] { "password" }, LogLevel.Information);
+
+        sut.NonQueryExecuting(SampleCommand(), new DbCommandInterceptionContext<int>());
+
+        var rendered = (string)Assert.Single(logger.Entries).GetValue("Parameters")!;
+        Assert.DoesNotContain("hunter2", rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("@password=***", rendered, StringComparison.Ordinal);
+    }
+
+
+
+    [Fact]
+    public void Executing_with_null_command_logs_nothing()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingCommandInterceptor(logger, Array.Empty<string>(), LogLevel.Information);
+
+        sut.NonQueryExecuting(null!, new DbCommandInterceptionContext<int>());
+
+        Assert.Empty(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void Executed_without_an_exception_logs_nothing()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingCommandInterceptor(logger, Array.Empty<string>(), LogLevel.Information);
+
+        sut.NonQueryExecuted(SampleCommand(), new DbCommandInterceptionContext<int>());
+
+        Assert.Empty(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void NonQueryExecuted_with_an_exception_logs_it_at_Error()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingCommandInterceptor(logger, Array.Empty<string>(), LogLevel.Information);
+        var boom = new InvalidOperationException("boom");
+        var context = new DbCommandInterceptionContext<int> { Exception = boom };
+
+        sut.NonQueryExecuted(SampleCommand(), context);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.Same(boom, entry.Exception);
+    }
+
+
+
+    [Fact]
+    public void ReaderExecuted_with_an_exception_logs_it_at_Error()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingCommandInterceptor(logger, Array.Empty<string>(), LogLevel.Information);
+        var context = new DbCommandInterceptionContext<System.Data.Common.DbDataReader> { Exception = new Exception("x") };
+
+        sut.ReaderExecuted(SampleCommand(), context);
+
+        Assert.Equal(LogLevel.Error, Assert.Single(logger.Entries).Level);
+    }
+
+
+
+    [Fact]
+    public void ScalarExecuted_with_an_exception_logs_it_at_Error()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingCommandInterceptor(logger, Array.Empty<string>(), LogLevel.Information);
+        var context = new DbCommandInterceptionContext<object> { Exception = new Exception("x") };
+
+        sut.ScalarExecuted(SampleCommand(), context);
+
+        Assert.Equal(LogLevel.Error, Assert.Single(logger.Entries).Level);
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/LoggingConnectionInterceptorTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/LoggingConnectionInterceptorTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Data.Entity.Infrastructure.Interception;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit;
+
+public class LoggingConnectionInterceptorTests
+{
+    [Fact]
+    public void Opening_logs_the_connection_at_the_configured_level()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingConnectionInterceptor(logger, LogLevel.Debug);
+
+        sut.Opening(new FakeDbConnection(), new DbConnectionInterceptionContext());
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Debug, entry.Level);
+        // The rich connection entry carries the redacted connection string.
+        var connectionString = (string)entry.GetValue("ConnectionString")!;
+        Assert.DoesNotContain("secret", connectionString, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Fact]
+    public void Opening_with_null_connection_logs_nothing()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingConnectionInterceptor(logger, LogLevel.Information);
+
+        sut.Opening(null!, new DbConnectionInterceptionContext());
+
+        Assert.Empty(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void Opened_without_an_exception_logs_a_state_transition()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingConnectionInterceptor(logger, LogLevel.Information);
+
+        sut.Opened(new FakeDbConnection(), new DbConnectionInterceptionContext());
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+        Assert.Contains("opened", entry.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Fact]
+    public void Opened_with_an_exception_logs_it_at_Error()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingConnectionInterceptor(logger, LogLevel.Information);
+        var boom = new InvalidOperationException("open failed");
+        var context = new DbConnectionInterceptionContext { Exception = boom };
+
+        sut.Opened(new FakeDbConnection(), context);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.Same(boom, entry.Exception);
+    }
+
+
+
+    [Fact]
+    public void Closing_logs_nothing()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingConnectionInterceptor(logger, LogLevel.Information);
+
+        sut.Closing(new FakeDbConnection(), new DbConnectionInterceptionContext());
+
+        Assert.Empty(logger.Entries);
+    }
+
+
+
+    [Fact]
+    public void Closed_without_an_exception_logs_a_state_transition()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingConnectionInterceptor(logger, LogLevel.Information);
+
+        sut.Closed(new FakeDbConnection(), new DbConnectionInterceptionContext());
+
+        Assert.Contains("closed", Assert.Single(logger.Entries).Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Fact]
+    public void Closed_with_an_exception_logs_it_at_Error()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingConnectionInterceptor(logger, LogLevel.Information);
+        var context = new DbConnectionInterceptionContext { Exception = new Exception("close failed") };
+
+        sut.Closed(new FakeDbConnection(), context);
+
+        Assert.Equal(LogLevel.Error, Assert.Single(logger.Entries).Level);
+    }
+
+
+
+    [Fact]
+    public void Property_and_transaction_callbacks_are_silent_noops()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingConnectionInterceptor(logger, LogLevel.Information);
+        var c = new FakeDbConnection();
+
+        sut.BeganTransaction(c, new BeginTransactionInterceptionContext());
+        sut.BeginningTransaction(c, new BeginTransactionInterceptionContext());
+        sut.ConnectionStringGetting(c, new DbConnectionInterceptionContext<string>());
+        sut.ConnectionStringGot(c, new DbConnectionInterceptionContext<string>());
+        sut.ConnectionStringSetting(c, new DbConnectionPropertyInterceptionContext<string>());
+        sut.ConnectionStringSet(c, new DbConnectionPropertyInterceptionContext<string>());
+        sut.ConnectionTimeoutGetting(c, new DbConnectionInterceptionContext<int>());
+        sut.ConnectionTimeoutGot(c, new DbConnectionInterceptionContext<int>());
+        sut.DatabaseGetting(c, new DbConnectionInterceptionContext<string>());
+        sut.DatabaseGot(c, new DbConnectionInterceptionContext<string>());
+        sut.DataSourceGetting(c, new DbConnectionInterceptionContext<string>());
+        sut.DataSourceGot(c, new DbConnectionInterceptionContext<string>());
+        sut.Disposing(c, new DbConnectionInterceptionContext());
+        sut.Disposed(c, new DbConnectionInterceptionContext());
+        sut.EnlistedTransaction(c, new EnlistTransactionInterceptionContext());
+        sut.EnlistingTransaction(c, new EnlistTransactionInterceptionContext());
+        sut.ServerVersionGetting(c, new DbConnectionInterceptionContext<string>());
+        sut.ServerVersionGot(c, new DbConnectionInterceptionContext<string>());
+        sut.StateGetting(c, new DbConnectionInterceptionContext<System.Data.ConnectionState>());
+        sut.StateGot(c, new DbConnectionInterceptionContext<System.Data.ConnectionState>());
+
+        Assert.Empty(logger.Entries);
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/LoggingTransactionInterceptorTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/LoggingTransactionInterceptorTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Data.Entity.Infrastructure.Interception;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.TestHelpers;
+
+namespace Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit;
+
+public class LoggingTransactionInterceptorTests
+{
+    [Fact]
+    public void Committing_logs_at_the_configured_level()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingTransactionInterceptor(logger, LogLevel.Debug);
+
+        sut.Committing(null!, new DbTransactionInterceptionContext());
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Debug, entry.Level);
+        Assert.Contains("committing", entry.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Fact]
+    public void Committed_without_an_exception_logs_a_state_transition()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingTransactionInterceptor(logger, LogLevel.Information);
+
+        sut.Committed(null!, new DbTransactionInterceptionContext());
+
+        Assert.Contains("committed", Assert.Single(logger.Entries).Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Fact]
+    public void Committed_with_an_exception_logs_it_at_Error()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingTransactionInterceptor(logger, LogLevel.Information);
+        var boom = new InvalidOperationException("commit failed");
+        var context = new DbTransactionInterceptionContext { Exception = boom };
+
+        sut.Committed(null!, context);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.Same(boom, entry.Exception);
+    }
+
+
+
+    [Fact]
+    public void RollingBack_logs_at_the_configured_level()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingTransactionInterceptor(logger, LogLevel.Information);
+
+        sut.RollingBack(null!, new DbTransactionInterceptionContext());
+
+        Assert.Contains("rolling back", Assert.Single(logger.Entries).Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Fact]
+    public void RolledBack_without_an_exception_logs_a_state_transition()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingTransactionInterceptor(logger, LogLevel.Information);
+
+        sut.RolledBack(null!, new DbTransactionInterceptionContext());
+
+        Assert.Contains("rolled back", Assert.Single(logger.Entries).Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Fact]
+    public void RolledBack_with_an_exception_logs_it_at_Error()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingTransactionInterceptor(logger, LogLevel.Information);
+        var context = new DbTransactionInterceptionContext { Exception = new Exception("rollback failed") };
+
+        sut.RolledBack(null!, context);
+
+        Assert.Equal(LogLevel.Error, Assert.Single(logger.Entries).Level);
+    }
+
+
+
+    [Fact]
+    public void Accessor_callbacks_are_silent_noops()
+    {
+        var logger = new RecordingLogger();
+        var sut = new LoggingTransactionInterceptor(logger, LogLevel.Information);
+
+        sut.ConnectionGetting(null!, new DbTransactionInterceptionContext<System.Data.Common.DbConnection>());
+        sut.ConnectionGot(null!, new DbTransactionInterceptionContext<System.Data.Common.DbConnection>());
+        sut.IsolationLevelGetting(null!, new DbTransactionInterceptionContext<System.Data.IsolationLevel>());
+        sut.IsolationLevelGot(null!, new DbTransactionInterceptionContext<System.Data.IsolationLevel>());
+        sut.Disposing(null!, new DbTransactionInterceptionContext());
+        sut.Disposed(null!, new DbTransactionInterceptionContext());
+
+        Assert.Empty(logger.Entries);
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/TestHelpers/FakeDbCommand.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/TestHelpers/FakeDbCommand.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+
+namespace Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.TestHelpers;
+
+/// <summary>
+/// Minimal <see cref="DbCommand"/> test double for exercising <c>LogDbCommand</c> on every
+/// target framework (no live provider needed). Only the members <c>LogDbCommand</c> reads —
+/// <see cref="CommandText"/> and <see cref="DbParameterCollection"/> — are functional; the
+/// execution surface throws.
+/// </summary>
+internal sealed class FakeDbCommand : DbCommand
+{
+    private readonly FakeDbParameterCollection _parameters = new();
+
+    // AllowNullAttribute is public only on netcoreapp3.0+/net5+ (it's internal on the
+    // .NET Framework TFMs). The CS8765 it satisfies only fires where the base BCL setter
+    // is nullable-annotated, which is the same set of TFMs — so guarding both together.
+#if NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.AllowNull]
+#endif
+    public override string CommandText { get; set; } = string.Empty;
+
+    public override int CommandTimeout { get; set; }
+
+    public override CommandType CommandType { get; set; }
+
+    public override bool DesignTimeVisible { get; set; }
+
+    public override UpdateRowSource UpdatedRowSource { get; set; }
+
+    protected override DbConnection? DbConnection { get; set; }
+
+    protected override DbParameterCollection DbParameterCollection => _parameters;
+
+    protected override DbTransaction? DbTransaction { get; set; }
+
+    public void AddParameter(string name, object? value)
+    {
+        _parameters.Add(new FakeDbParameter { ParameterName = name, Value = value });
+    }
+
+    public override void Cancel()
+    {
+    }
+
+    public override int ExecuteNonQuery() => throw new NotSupportedException();
+
+    public override object? ExecuteScalar() => throw new NotSupportedException();
+
+    public override void Prepare()
+    {
+    }
+
+    protected override DbParameter CreateDbParameter() => new FakeDbParameter();
+
+    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => throw new NotSupportedException();
+}
+
+
+internal sealed class FakeDbParameter : DbParameter
+{
+    public override DbType DbType { get; set; }
+
+    public override ParameterDirection Direction { get; set; }
+
+    public override bool IsNullable { get; set; }
+
+    // AllowNullAttribute is public only on netcoreapp3.0+/net5+ (it's internal on the
+    // .NET Framework TFMs). The CS8765 it satisfies only fires where the base BCL setter
+    // is nullable-annotated, which is the same set of TFMs — so guarding both together.
+#if NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.AllowNull]
+#endif
+    public override string ParameterName { get; set; } = string.Empty;
+
+    public override int Size { get; set; }
+
+    // AllowNullAttribute is public only on netcoreapp3.0+/net5+ (it's internal on the
+    // .NET Framework TFMs). The CS8765 it satisfies only fires where the base BCL setter
+    // is nullable-annotated, which is the same set of TFMs — so guarding both together.
+#if NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.AllowNull]
+#endif
+    public override string SourceColumn { get; set; } = string.Empty;
+
+    public override bool SourceColumnNullMapping { get; set; }
+
+    // AllowNullAttribute is public only on netcoreapp3.0+/net5+ (it's internal on the
+    // .NET Framework TFMs). The CS8765 it satisfies only fires where the base BCL setter
+    // is nullable-annotated, which is the same set of TFMs — so guarding both together.
+#if NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.AllowNull]
+#endif
+    public override object? Value { get; set; }
+
+    public override void ResetDbType()
+    {
+    }
+}
+
+
+/// <summary>
+/// Backing collection for <see cref="FakeDbCommand"/>. Implements only <see cref="Count"/> and
+/// enumeration (what <c>ToDictionary(DbParameterCollection)</c> uses) plus <c>Add</c>; the rest
+/// throw, as they are never reached by the logging path under test.
+/// </summary>
+internal sealed class FakeDbParameterCollection : DbParameterCollection
+{
+    private readonly List<DbParameter> _items = new();
+
+    public override int Count => _items.Count;
+
+    public override object SyncRoot => _items;
+
+    public override int Add(object value)
+    {
+        _items.Add((DbParameter)value);
+        return _items.Count - 1;
+    }
+
+    public override IEnumerator GetEnumerator() => _items.GetEnumerator();
+
+    protected override DbParameter GetParameter(int index) => _items[index];
+
+    protected override DbParameter GetParameter(string parameterName) => throw new NotSupportedException();
+
+    public override void AddRange(Array values) => throw new NotSupportedException();
+
+    public override void Clear() => _items.Clear();
+
+    public override bool Contains(object value) => throw new NotSupportedException();
+
+    public override bool Contains(string value) => throw new NotSupportedException();
+
+    public override void CopyTo(Array array, int index) => throw new NotSupportedException();
+
+    public override int IndexOf(object value) => throw new NotSupportedException();
+
+    public override int IndexOf(string parameterName) => throw new NotSupportedException();
+
+    public override void Insert(int index, object value) => throw new NotSupportedException();
+
+    public override void Remove(object value) => throw new NotSupportedException();
+
+    public override void RemoveAt(int index) => throw new NotSupportedException();
+
+    public override void RemoveAt(string parameterName) => throw new NotSupportedException();
+
+    protected override void SetParameter(int index, DbParameter value) => throw new NotSupportedException();
+
+    protected override void SetParameter(string parameterName, DbParameter value) => throw new NotSupportedException();
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/TestHelpers/FakeDbConnection.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/TestHelpers/FakeDbConnection.cs
@@ -1,0 +1,41 @@
+using System.Data;
+using System.Data.Common;
+
+namespace Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.TestHelpers;
+
+/// <summary>
+/// Minimal closed <see cref="DbConnection"/> test double — just enough for
+/// <c>LogDbConnection</c> to read its benign properties without a live provider. It never
+/// opens, so the <see cref="ServerVersion"/> path (guarded behind an Open check) is not hit.
+/// </summary>
+internal sealed class FakeDbConnection : DbConnection
+{
+#if NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.AllowNull]
+#endif
+    public override string ConnectionString { get; set; } = "Server=localhost;Database=Test;User Id=sa;Password=secret";
+
+    public override string Database => "Test";
+
+    public override string DataSource => "localhost";
+
+    public override string ServerVersion => "1.0";
+
+    public override ConnectionState State => ConnectionState.Closed;
+
+    public override void ChangeDatabase(string databaseName)
+    {
+    }
+
+    public override void Close()
+    {
+    }
+
+    public override void Open()
+    {
+    }
+
+    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new System.NotSupportedException();
+
+    protected override DbCommand CreateDbCommand() => throw new System.NotSupportedException();
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/TestHelpers/RecordingLogger.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/TestHelpers/RecordingLogger.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.TestHelpers;
+
+internal sealed class RecordingLogger : ILogger
+{
+    public List<LogEntry> Entries { get; } = new List<LogEntry>();
+
+    public LogLevel MinimumLevel { get; set; } = LogLevel.Trace;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel >= MinimumLevel;
+
+    public void Log<TState>
+    (
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter
+    )
+    {
+        var message = formatter(state, exception);
+        var values = state as IReadOnlyList<KeyValuePair<string, object?>>;
+        Entries.Add(new LogEntry(logLevel, message, exception, values));
+    }
+}
+
+
+internal sealed class LogEntry
+{
+    public LogEntry(LogLevel level, string message, Exception? exception, IReadOnlyList<KeyValuePair<string, object?>>? values)
+    {
+        Level = level;
+        Message = message;
+        Exception = exception;
+        Values = values;
+    }
+
+    public LogLevel Level { get; }
+
+    public string Message { get; }
+
+    public Exception? Exception { get; }
+
+    public IReadOnlyList<KeyValuePair<string, object?>>? Values { get; }
+
+    public object? GetValue(string name)
+    {
+        if (Values is null)
+        {
+            return null;
+        }
+
+        foreach (var kvp in Values)
+        {
+            if (string.Equals(kvp.Key, name, StringComparison.Ordinal))
+            {
+                return kvp.Value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net462;net48;net8.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="EntityFramework" Version="6.5.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.Logging.Data.EntityFramework6\Wolfgang.Extensions.Logging.Data.EntityFramework6.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Closes #66 (the EF6 companion package; the `LogDbCommand(DbCommand)` bridge it depends on landed in #139).

## What
A new package **`Wolfgang.Extensions.Logging.Data.EntityFramework6`** that gives legacy EF6 apps **passive** structured logging — register once at startup, every `DbContext` logs automatically with zero per-query call sites.

```csharp
EntityFramework6Logging.AddLoggingInterceptors(
    logger,
    excludedParameterNames: new[] { "password" },  // optional redaction
    level: LogLevel.Information);                   // optional
```

## How
Three internal interceptors wired into EF6's `DbInterception` pipeline:

| Interceptor | Logs |
|---|---|
| `LoggingCommandInterceptor` | `*Executing` → `LogDbCommand` (parameter snapshot + redaction); `*Executed` → `LogLevel.Error` when the context carries an exception |
| `LoggingConnectionInterceptor` | `Opening` → `LogDbConnection` (connection-string redaction); open/close transitions + error surfacing. The ~20 property-getter callbacks EF6 forces are deliberate no-ops |
| `LoggingTransactionInterceptor` | commit / rollback transitions + error |

`DbInterception.Add` is **process-global and not idempotent**, so `AddLoggingInterceptors` guards against double-registration per logger instance (a `HashSet` keyed by reference identity). An internal registration seam lets tests assert what's registered without mutating EF6's global state.

## Design decisions (issue's open questions)
- **Same repo** (new `src` project) — shared README/CHANGELOG/CI, ships as a second package.
- **Static dup-guard** (not just documented) — matches the spike's warning.
- **`LogDbCommand(DbCommand)` bridge in core** (shipped #139) rather than duplicating extraction here.

## Testing
- **29 unit tests**, no live SQL Server — fake `DbCommand`/`DbConnection` + real EF6 interception contexts (the `Exception` setter is public, so failure paths are exercised directly).
- **100% line coverage** on the new assembly.
- Verified locally: full solution builds clean; tests pass across **all 4 test TFMs** (net462, net48, net8.0, net10.0).

Targets `net462;net48;netstandard2.1`. EntityFramework 6.5.2.

## ⚠️ Release follow-up (not in this PR)
This adds a **new package id**. Before the next release, `release.yaml`'s NuGet push must cover `Wolfgang.Extensions.Logging.Data.EntityFramework6*` (the API-key/package glob), or the publish 403s — a known multi-package-family gotcha. Docs (docfx) wiring for the second assembly is likewise a release-prep item.