### PR TITLE
Add canonical W favicon to docs

### DIFF
--- a/docfx_project/favicon.svg
+++ b/docfx_project/favicon.svg
@@ -1,12 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
-  <style>
-    .w {
-      font-family: Georgia, "Times New Roman", "DejaVu Serif", serif;
-      font-weight: 700;
-      font-size: 30px;
-      fill: #7c23bb;
-      filter: drop-shadow(0 0 2px rgba(124, 35, 187, 0.5));
-    }
-  </style>
-  <text class="w" x="16" y="26" text-anchor="middle">W</text>
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Wolfgang">
+  <rect x="0" y="0" width="32" height="32" rx="6" ry="6" fill="#7c5cf6"/>
+  <rect x="1.6" y="1.6" width="28.8" height="28.8" rx="5.4" ry="5.4" fill="#4a1e9e"/>
+  <text x="16" y="16" text-anchor="middle" dominant-baseline="central"
+        font-family="'Segoe UI Black', 'Arial Black', system-ui, sans-serif"
+        font-weight="900" font-size="20" fill="#ffffff">W</text>
 </svg>


### PR DESCRIPTION
Brings this repo in line with the canonical Wolfgang docs favicon (white **W** in Segoe UI Black on a purple `#4a1e9e` rounded tile with a `#7c5cf6` rim for dark-theme edge separation).

## Files
- `docfx_project/favicon.svg` — primary, scalable, linked via the docfx modern template
- `docfx_project/favicon.ico` — multi-size legacy fallback (16/32/48)
- `docfx_project/apple-touch-icon.png` — iOS home-screen (180×180)

## Wiring
- `docfx.json`: assets registered as build `resource` files + `_appFaviconPath: favicon.svg`

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)