### PR TITLE
fix(docfx): split metadata per-project so EF6 companion builds against net48

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -5,7 +5,7 @@
       "src": [
         {
           "files": [
-            "src/**/*.csproj"
+            "src/Wolfgang.Extensions.Logging.Data/**/*.csproj"
           ],
           "src": "../"
         }
@@ -13,6 +13,22 @@
       "dest": "api",
       "properties": {
         "TargetFramework": "net10.0"
+      },
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false
+    },
+    {
+      "src": [
+        {
+          "files": [
+            "src/Wolfgang.Extensions.Logging.Data.EntityFramework6/**/*.csproj"
+          ],
+          "src": "../"
+        }
+      ],
+      "dest": "api",
+      "properties": {
+        "TargetFramework": "net48"
       },
       "disableGitFeatures": false,
       "disableDefaultFilter": false


### PR DESCRIPTION
## Problem

The `release.yaml` run for v0.2.0 failed on both `Build & Deploy Documentation` and `Verify Documentation Builds`. DocFX metadata generation produced ~20 CS0234/CS0246 errors in the new `Wolfgang.Extensions.Logging.Data.EntityFramework6` companion project:

```
CS0234: The type or namespace name 'Entity' does not exist in the namespace 'System.Data'
CS0234: The type or namespace name 'Extensions' does not exist in the namespace 'Microsoft'
CS0246: The type or namespace name 'IDbCommandInterceptor' could not be found
CS0246: The type or namespace name 'ILogger' could not be found
...
```

## Root cause

`docfx_project/docfx.json` had a single `metadata` entry forcing `"TargetFramework": "net10.0"` for **every** project it discovered under `src/**/*.csproj`. But the EF6 companion project targets `net462;net48;netstandard2.1` — no `net10.0`. EntityFramework6 fundamentally requires .NET Framework or classic-compatible TFMs; it cannot be built for .NET Core-based TFMs.

Result: DocFX tried to compile `Wolfgang.Extensions.Logging.Data.EntityFramework6` on `net10.0`, EF6 package couldn't restore, all types unresolved → 20 errors → doc build failed → publish job skipped → release incomplete.

## Fix

Split the single `metadata` entry into two per-project entries, each with a compatible TFM:

| Project | `TargetFramework` |
|---|---|
| `Wolfgang.Extensions.Logging.Data` | `net10.0` (main package, has net10.0) |
| `Wolfgang.Extensions.Logging.Data.EntityFramework6` | `net48` (EF6 companion, .NET Framework only) |

Both write to the same `api` dest, so the generated docs still land in one API index; DocFX handles multiple metadata entries this way natively.

## After merge

Re-fire the v0.2.0 release (delete + recreate) to re-run `release.yaml` — this time both docs jobs should pass and the two packages (`Wolfgang.Extensions.Logging.Data` and `Wolfgang.Extensions.Logging.Data.EntityFramework6`) will publish to NuGet.