### PR TITLE
ci: add ReSharper InspectCode parallel check (#136)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -253,7 +253,15 @@ jobs:
     name: "ReSharper InspectCode"
     runs-on: ubuntu-latest
     needs: detect-projects
-    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    # SAME-REPO PRs ONLY. Under pull_request_target this job checks out and BUILDS
+    # PR code while holding security-events: write — so it must never run for a
+    # fork (untrusted contributor). `github.repository` is always the base repo
+    # under pull_request_target, so the repo != repo-template check does NOT
+    # exclude forks; the head-repo comparison does.
+    if: >-
+      github.repository != 'Chris-Wolfgang/repo-template'
+      && needs.detect-projects.outputs.has-projects == 'true'
+      && github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 20
     permissions:
       contents: read
@@ -266,23 +274,31 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
 
+      - name: Fetch trusted analysis config from main
+        # pull_request_target hardening: don't let the PR's own analyzer config
+        # drive InspectCode. Overwrite the analysis-relevant files with main's
+        # versions before building (mirrors the other jobs' trusted-config fetch).
+        run: |
+          git fetch origin main:main-ref
+          for f in .editorconfig Directory.Build.props Directory.Build.targets; do
+            if git cat-file -e "main-ref:$f" 2>/dev/null; then
+              git checkout main-ref -- "$f"
+            fi
+          done
+          # .globalconfig / .ruleset (any path)
+          while IFS= read -r f; do
+            [ -n "$f" ] && git checkout main-ref -- "$f" 2>/dev/null || true
+          done < <(git ls-tree -r --name-only main-ref | grep -E '\.(globalconfig|ruleset)$' || true)
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
-      - name: Restore + Build (Release)
+      - name: Resolve solution
+        id: sln
         run: |
-          dotnet restore
-          dotnet build -c Release --no-restore
-
-      - name: Install JetBrains.ReSharper.GlobalTools
-        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
-
-      - name: Run InspectCode
-        run: |
-          # Find a solution to inspect. Prefer .slnx (new format) then .sln.
-          # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
+          # Prefer .slnx (new format) then .sln. Fail loudly if neither exists.
           SLN=$(ls *.slnx 2>/dev/null | head -n1)
           if [ -z "$SLN" ]; then
             SLN=$(ls *.sln 2>/dev/null | head -n1)
@@ -291,8 +307,23 @@ jobs:
             echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
             exit 1
           fi
-          echo "Inspecting: $SLN"
-          jb inspectcode "$SLN" \
+          echo "Solution: $SLN"
+          echo "sln=$SLN" >> "$GITHUB_OUTPUT"
+
+      - name: Restore + Build (Release)
+        # Build the resolved solution explicitly (not a bare `dotnet build`), so
+        # repos with more than one solution/project at the root don't fail on
+        # CLI disambiguation.
+        run: |
+          dotnet restore "${{ steps.sln.outputs.sln }}"
+          dotnet build "${{ steps.sln.outputs.sln }}" -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        run: |
+          jb inspectcode "${{ steps.sln.outputs.sln }}" \
             --output=inspect.sarif \
             --format=sarif \
             --severity=WARNING \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -241,9 +241,84 @@ jobs:
           fi
 
   # ============================================================================
+  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
+  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
+  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
+  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
+  # annotations). `error`-severity findings fail the job; `warning`-severity
+  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
+  # filter). Tune the noise floor via .DotSettings at the repo root.
+  # ============================================================================
+  inspectcode:
+    name: "ReSharper InspectCode"
+    runs-on: ubuntu-latest
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore + Build (Release)
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        run: |
+          # Find a solution to inspect. Prefer .slnx (new format) then .sln.
+          # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
+          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          if [ -z "$SLN" ]; then
+            SLN=$(ls *.sln 2>/dev/null | head -n1)
+          fi
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+            exit 1
+          fi
+          echo "Inspecting: $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        run: |
+          # SARIF level=error fails the job; warnings still upload (visible in
+          # Security → Code scanning) but don't gate merge — raise to `error`
+          # later when the noise floor is acceptable.
+          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No error-severity InspectCode findings."
+
+  # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
-  test-linux-core: 
+  test-linux-core:
     name: "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate"
     runs-on:  ubuntu-latest
     needs: detect-projects


### PR DESCRIPTION
Refs #136 (partial — the canonical .DotSettings noise-floor is a tracked follow-up; repo-template has none yet).

## What
Syncs the canonical `inspectcode` job from `repo-template` into `pr.yaml`. It:
- runs on `ubuntu-latest` **parallel** to the test stages (`needs: detect-projects` only — no serial dependency on a test job),
- builds Release, runs `jb inspectcode` (JetBrains.ReSharper.GlobalTools) over the `.slnx`,
- uploads SARIF to GitHub **Code Scanning** (Security tab + inline PR annotations),
- **gates on `error`-severity findings**; `warning`-severity surfaces but doesn't fail (the designed noise floor).

## Local verification
Ran the exact CI step against `Extensions-Logging-Data.slnx`:
- **0 error-severity findings → the gate passes on current main.**
- 181 warnings (non-gating), top rule `RS0016` ×110 (PublicApiAnalyzers surface-tracking — the same findings the normal TWEA build doesn't enforce). These upload to Code Scanning but don't block merge.

YAML validated; `inspectcode` registers alongside `secrets-scan`, `detect-projects`, `test-linux-core`, `test-windows`, `test-macos-core`, `security-scan`.

## Matches canonical exactly
repo-template ships no `.DotSettings` and no `build-pr.ps1` InspectCode step yet, so neither is added here (would be a separate fleet decision).

## Follow-ups (not in this PR)
1. **Branch ruleset:** add `ReSharper InspectCode` to `main`'s required status checks — do this **after** this lands so the check has a green run first, or PRs stall.
2. **Noise-floor `.DotSettings`:** the 181 warnings (esp. RS0016 ×110) are candidates to silence at the canonical level when the fleet tunes the profile.

## ⚠️ Merge note
Touches `pr.yaml` (protected workflow file) → the `Detect .NET Projects` guard fails by design → **needs maintainer admin-bypass** to merge.
