### PR TITLE
ci: workflow security audit — actionlint + zizmor (#104)

### DIFF
--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -21,6 +21,9 @@ jobs:
   actionlint:
     name: actionlint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write   # reviewdog creates a Check run to surface annotations
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -30,7 +33,9 @@ jobs:
       - name: Run actionlint
         uses: reviewdog/action-actionlint@v1
         with:
-          reporter: github-pr-check
+          # github-check (not github-pr-check) so annotations are produced on
+          # both pull_request and push-to-main runs, not only in PR context.
+          reporter: github-check
           fail_level: error
 
   zizmor:

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -1,0 +1,77 @@
+# ============================================================================
+# Workflow Security — audits the GitHub Actions YAML itself (not the code).
+# actionlint catches syntax / expression / shell errors; zizmor audits for
+# workflow-level security issues (injection, over-broad permissions, dangerous
+# triggers, unpinned actions). Accepted findings are documented in
+# .github/zizmor.yml. Runs on `pull_request` (safe — no secrets, no PR code
+# executed in a privileged context) rather than `pull_request_target`.
+# ============================================================================
+name: Workflow Security
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          reporter: github-pr-check
+          fail_level: error
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # upload SARIF to code scanning
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run zizmor (SARIF)
+        id: zizmor
+        run: |
+          # Version-pinned for reproducibility. Config (.github/zizmor.yml) is
+          # auto-discovered. --min-severity=high so only high-severity findings
+          # gate; informational/low/medium still appear in Code Scanning.
+          set +e
+          pipx run zizmor==1.26.1 --persona=regular --min-severity=high \
+            --format=sarif .github/workflows/ > zizmor.sarif
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Upload SARIF to code-scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: zizmor.sarif
+
+      - name: Gate on high-severity findings
+        run: |
+          if [ "${{ steps.zizmor.outputs.exit }}" != "0" ]; then
+            echo "::error::zizmor found high-severity workflow issue(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No high-severity zizmor findings."

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,23 @@
+# zizmor configuration — GitHub Actions workflow security audit.
+# https://docs.zizmor.sh/configuration/
+#
+# Accepted suppressions (reason required per the maintenance policy):
+#   - unpinned-uses:      the fleet pins actions to floating major-version TAGS
+#                         (actions/checkout@v7), not commit hashes — a deliberate
+#                         maintenance decision (repo-template #425). `ref-pin`
+#                         accepts a tag/branch ref, so tag pins are clean and only
+#                         a mutable-branch/no-ref pin is flagged.
+#   - dangerous-triggers: pr.yaml uses `pull_request_target` ON PURPOSE so the
+#                         workflow definition comes from main (a PR branch cannot
+#                         weaken its own CI). The risk is mitigated by the
+#                         "Detect .NET Projects" job, which fetches every trusted
+#                         config file from main and never checks out PR code into
+#                         a privileged context. Intentional and reviewed.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": ref-pin
+  dangerous-triggers:
+    ignore:
+      - pr.yaml


### PR DESCRIPTION
Closes #104.

## What
`.github/workflows/workflow-security.yaml` — two jobs on every PR + push to main:
- **actionlint** (via `reviewdog/action-actionlint`) — GitHub Actions syntax/expression/shell lint, inline PR annotations, fails on `error`.
- **zizmor** — workflow security audit (injection, permissions, dangerous triggers, unpinned actions). SARIF → **Code Scanning**; **gates on high-severity** (`--min-severity=high`), non-high still surfaces.

Runs on `pull_request` (not `pull_request_target`) — it needs no secrets and executes no PR code in a privileged context, so it's the safer trigger.

## `.github/zizmor.yml` — documented accepted suppressions
| Rule | Disposition | Reason |
|---|---|---|
| `unpinned-uses` | `ref-pin` policy | Fleet pins actions to floating major tags (`@v7`), not commit hashes — deliberate (repo-template #425). |
| `dangerous-triggers` | ignored for `pr.yaml` | `pull_request_target` is intentional and mitigated by the "Detect .NET Projects" fetch-config-from-main guard. |

## Local calibration (before pushing)
Ran both tools against the actual repo:
- **actionlint:** 0 findings, exit 0.
- **zizmor:** **44 high → 0 high** after the documented config; exit 0. Verified the two new workflow files also pass.

## Fleet note
Fleet-wide thorough-review item; `repo-template` doesn't have it — **recommend promoting to canonical + fan-out**.

## ⚠️ Merge note
New workflow file → `Detect .NET Projects` guard fails by design → **needs maintainer admin-bypass**.