### PR TITLE
test: XML-doc <example> rot detection (#93)

### DIFF
--- a/Extensions-Logging-Data.slnx
+++ b/Extensions-Logging-Data.slnx
@@ -53,6 +53,7 @@
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/Wolfgang.Extensions.Logging.Data.Tests.Integration.csproj" />
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj" />
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.csproj" />
+    <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/Wolfgang.Extensions.Logging.Data.Tests.Docs.csproj" />
   </Folder>
 </Solution>
 

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/AssemblyInfo.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
+// This assembly's code is test scaffolding (a Roslyn doc-example compiler), not
+// shippable surface — exclude it from the per-module coverage gate.
+[assembly: ExcludeFromCodeCoverage]

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/DocExampleCompilationTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/DocExampleCompilationTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Docs;
+
+/// <summary>
+/// Compiles every <c>&lt;example&gt;&lt;code&gt;</c> block found in the XML-doc comments of
+/// the source, catching "documentation rot" — an example that stops compiling because the
+/// API it demonstrates was renamed, removed, or changed. Each block is wrapped in a minimal
+/// async harness (ambient <c>logger</c> / <c>connection</c> / <c>connectionString</c> /
+/// <c>command</c> are injected only when a block uses but does not declare them) and compiled
+/// with Roslyn against the same reference set the test process runs on.
+/// </summary>
+public class DocExampleCompilationTests
+{
+    private static readonly (string Name, string Declaration)[] AmbientCandidates =
+    {
+        ("logger", "Microsoft.Extensions.Logging.ILogger logger = null!;"),
+        ("connectionString", "string connectionString = null!;"),
+        ("connection", "System.Data.Common.DbConnection connection = null!;"),
+        ("command", "System.Data.Common.DbCommand command = null!;"),
+    };
+
+    public static IEnumerable<object[]> Examples()
+    {
+        var srcDir = FindSourceDirectory();
+        foreach (var file in Directory.EnumerateFiles(srcDir, "*.cs", SearchOption.AllDirectories))
+        {
+            var text = File.ReadAllText(file);
+            var i = 0;
+            foreach (var code in ExtractCodeBlocks(text))
+            {
+                i++;
+                yield return new object[] { $"{Path.GetFileName(file)}#{i}", code };
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Examples))]
+    public void DocExample_compiles(string id, string code)
+    {
+        _ = id;
+        var program = BuildProgram(code);
+
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Where(p => p.Length > 0)
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create
+        (
+            "DocExamples",
+            new[] { CSharpSyntaxTree.ParseText(program) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable)
+        );
+
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => d.ToString())
+            .ToList();
+
+        Assert.True
+        (
+            errors.Count == 0,
+            $"Doc example {id} does not compile:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}{Environment.NewLine}--- generated ---{Environment.NewLine}{program}"
+        );
+    }
+
+    [Fact]
+    public void At_least_one_example_was_discovered()
+    {
+        // Guards against the extraction silently finding nothing (e.g. a regex or path
+        // regression) — which would make DocExample_compiles a vacuous green.
+        Assert.NotEmpty(Examples());
+    }
+
+    private static string BuildProgram(string snippet)
+    {
+        var declared = new HashSet<string>(
+            Regex.Matches(snippet, @"\b(?:using\s+)?var\s+(\w+)\s*=")
+                 .Select(m => m.Groups[1].Value));
+
+        var ambient = new StringBuilder();
+        foreach (var (name, declaration) in AmbientCandidates)
+        {
+            var usesIt = Regex.IsMatch(snippet, $@"\b{name}\b");
+            if (usesIt && !declared.Contains(name))
+            {
+                ambient.Append("        ").Append(declaration).Append('\n');
+            }
+        }
+
+        return
+            "using System;\n" +
+            "using System.Collections.Generic;\n" +
+            "using System.Data.Common;\n" +
+            "using System.Data.SqlClient;\n" +
+            "using System.Threading.Tasks;\n" +
+            "using Microsoft.Extensions.Logging;\n" +
+            "using Wolfgang.Extensions.Logging.Data;\n" +
+            "internal class __DocExampleHarness\n{\n" +
+            "    private async Task __RunAsync()\n    {\n" +
+            ambient +
+            snippet + "\n" +
+            "        await Task.CompletedTask;\n" +
+            "    }\n}\n";
+    }
+
+    private static IEnumerable<string> ExtractCodeBlocks(string fileText)
+    {
+        // Match a <code> ... </code> region inside a run of `///` comment lines.
+        foreach (Match m in Regex.Matches(fileText, @"///\s*<code>\s*\r?\n(?<body>.*?)///\s*</code>", RegexOptions.Singleline))
+        {
+            var body = m.Groups["body"].Value;
+            var lines = body.Split('\n')
+                .Select(l => l.TrimEnd('\r'))
+                .Select(StripDocPrefix)
+                .ToList();
+            var code = WebUtility.HtmlDecode(string.Join("\n", lines)).Trim();
+            if (code.Length > 0)
+            {
+                yield return code;
+            }
+        }
+    }
+
+    private static string StripDocPrefix(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.StartsWith("///", StringComparison.Ordinal))
+        {
+            trimmed = trimmed.Substring(3);
+            if (trimmed.StartsWith(" ", StringComparison.Ordinal))
+            {
+                trimmed = trimmed.Substring(1);
+            }
+            return trimmed;
+        }
+        return line;
+    }
+
+    private static string FindSourceDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "Wolfgang.Extensions.Logging.Data");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate src/Wolfgang.Extensions.Logging.Data walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/DocExampleCompilationTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/DocExampleCompilationTests.cs
@@ -33,6 +33,13 @@ public class DocExampleCompilationTests
         var srcDir = FindSourceDirectory();
         foreach (var file in Directory.EnumerateFiles(srcDir, "*.cs", SearchOption.AllDirectories))
         {
+            // Skip build outputs — bin/obj can contain generated .cs (and copied
+            // sources) that would be scanned needlessly.
+            if (IsUnderBuildOutput(file))
+            {
+                continue;
+            }
+
             var text = File.ReadAllText(file);
             var i = 0;
             foreach (var code in ExtractCodeBlocks(text))
@@ -47,7 +54,6 @@ public class DocExampleCompilationTests
     [MemberData(nameof(Examples))]
     public void DocExample_compiles(string id, string code)
     {
-        _ = id;
         var program = BuildProgram(code);
 
         var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
@@ -147,6 +153,13 @@ public class DocExampleCompilationTests
             return trimmed;
         }
         return line;
+    }
+
+    private static bool IsUnderBuildOutput(string path)
+    {
+        var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return parts.Any(p => string.Equals(p, "bin", StringComparison.OrdinalIgnoreCase)
+                           || string.Equals(p, "obj", StringComparison.OrdinalIgnoreCase));
     }
 
     private static string FindSourceDirectory()

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/Wolfgang.Extensions.Logging.Data.Tests.Docs.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/Wolfgang.Extensions.Logging.Data.Tests.Docs.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Single modern TFM: this project compiles doc examples with Roslyn, which
+         needs net472+/net8+. No need to run it on the .NET Framework matrix. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+
+    <!-- Referenced so the types the doc examples use are on the compile reference
+         set (via TRUSTED_PLATFORM_ASSEMBLIES): the package itself, the logging
+         abstractions, and SqlConnection (used by the LogDbConnection examples). -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.Logging.Data\Wolfgang.Extensions.Logging.Data.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Closes #93.

## What
A new `net10.0` test project (`Tests.Docs`) that **extracts every `<example><code>` block** from the source XML-doc comments and **compiles each with Roslyn** against the live reference set. If an example stops compiling — because the API it shows was renamed, removed, or changed — the test fails with the exact compiler error.

## How it handles the tricky bits
- **Inconsistent ambient context:** example 3 *uses* an undeclared `connection`; examples 4/5 *declare* `using var connection = new SqlConnection(...)`. The harness injects ambient `logger`/`connection`/`connectionString`/`command` stubs **only for symbols a block uses but doesn't declare**, so both styles compile without collision.
- **References:** pulled from `TRUSTED_PLATFORM_ASSEMBLIES` — automatically includes the package, `Microsoft.Extensions.Logging.Abstractions`, and `SqlConnection` (`System.Data.SqlClient`).
- **CI-safe source location:** walks up from `AppContext.BaseDirectory` (no `CallerFilePath`, which breaks under CI's deterministic paths).
- **No vacuous green:** a guard test asserts ≥1 example was discovered.
- `[assembly: ExcludeFromCodeCoverage]` — this is test scaffolding, kept out of the per-module coverage gate.

## Verification (local)
- 5 example blocks + discovery guard → **6/6 pass**.
- **Proved it catches rot:** temporarily renamed `LogDbConnection`→`LogDbConnectionXXX` in one example → the test failed with `CS1061` naming the exact line; reverted.

## Fleet note
Fleet-wide thorough-review item; not in `repo-template` — recommend promoting the pattern to canonical.

## Merge note
No protected files — standard checks apply (should merge without bypass once green).