### PR TITLE
ci: ApiCompat ABI-compatibility release gate (#88)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -375,6 +375,17 @@ jobs:
           dotnet restore
           dotnet build --no-restore --configuration Release
 
+      # ABI-compatibility gate (#88): diff each built package assembly against the
+      # previous version published on NuGet. Fails the release if a non-major bump
+      # introduces an unsuppressed binary break. Complements PublicApiAnalyzers,
+      # which only diffs source-level signatures.
+      - name: Check ABI compatibility (ApiCompat)
+        shell: pwsh
+        run: |
+          dotnet tool install -g Microsoft.DotNet.ApiCompat.Tool
+          $env:PATH += [IO.Path]::PathSeparator + (Join-Path $env:USERPROFILE '.dotnet/tools')
+          ./scripts/Check-ApiCompatibility.ps1 -Configuration Release
+
       - name: Pack NuGet packages
         id: check-packages
         shell: pwsh

--- a/compat-suppressions.txt
+++ b/compat-suppressions.txt
@@ -1,0 +1,4 @@
+# ABI-compatibility suppressions for scripts/Check-ApiCompatibility.ps1.
+# One accepted/intentional break per line — an ApiCompat id (e.g. CP0002) or a
+# substring of the finding message. Only add entries for breaks that are
+# deliberate (typically in a MAJOR release), with the reason in the commit/PR.

--- a/scripts/Check-ApiCompatibility.ps1
+++ b/scripts/Check-ApiCompatibility.ps1
@@ -1,0 +1,130 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    ABI-compatibility gate: compares each freshly-built src package assembly
+    against the previous version published on NuGet using Microsoft.DotNet.ApiCompat,
+    and fails when a NON-major version bump introduces a breaking change.
+
+.DESCRIPTION
+    Complements PublicApiAnalyzers (which diffs signatures at source level). ApiCompat
+    catches binary/behavioural breaks — default-value changes, nullability flips,
+    removed members a consumer's compiled assembly binds to at runtime.
+
+    Per SemVer: MAJOR may break ABI; MINOR/PATCH may not. For a 0.x package every
+    bump is treated as potentially-breaking-allowed only when the MAJOR component is 0
+    AND the caller opts in via -Allow0xMinorBreaks (0.x MINOR bumps are permitted to
+    break per SemVer's 0.x clause). By default 0.x MINOR/PATCH breaks are reported and
+    fail, which is the safer stance for a library approaching 1.0.
+
+    Intentional, reviewed breaks are recorded one-per-line in compat-suppressions.txt
+    (an ApiCompat suppression id or a substring of the message) so they don't recur
+    silently.
+
+.NOTES
+    Requires the Microsoft.DotNet.ApiCompat.Tool global tool on PATH (installed by the
+    release workflow). Runnable locally: pwsh scripts/Check-ApiCompatibility.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$Configuration = 'Release',
+    [string]$SuppressionsFile = "$PSScriptRoot/../compat-suppressions.txt",
+    [switch]$Allow0xMinorBreaks
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Resolve-Path "$PSScriptRoot/.."
+$flat = 'https://api.nuget.org/v3-flatcontainer'
+
+$suppressions = @()
+if (Test-Path $SuppressionsFile) {
+    $suppressions = Get-Content $SuppressionsFile |
+        Where-Object { $_ -and -not $_.TrimStart().StartsWith('#') } |
+        ForEach-Object { $_.Trim() }
+}
+
+function Get-PreviousVersion([string]$packageId, [string]$currentVersion) {
+    $url = "$flat/$($packageId.ToLowerInvariant())/index.json"
+    try { $all = (Invoke-RestMethod -Uri $url -ErrorAction Stop).versions }
+    catch { return $null }   # 404 => package never published => first release
+    $cur = [version]($currentVersion -replace '[-+].*$', '')
+    $prev = $all |
+        Where-Object { $_ -notmatch '-' } |
+        ForEach-Object { [version]($_ -replace '[-+].*$', '') } |
+        Where-Object { $_ -lt $cur } |
+        Sort-Object |
+        Select-Object -Last 1
+    return $prev
+}
+
+$breakingTotal = 0
+$projects = Get-ChildItem -Path (Join-Path $repoRoot 'src') -Recurse -Filter '*.csproj'
+
+foreach ($proj in $projects) {
+    [xml]$xml = Get-Content $proj.FullName
+    $pg = $xml.Project.PropertyGroup
+    $packageId = ($pg.PackageId | Where-Object { $_ } | Select-Object -First 1)
+    if (-not $packageId) { $packageId = [IO.Path]::GetFileNameWithoutExtension($proj.Name) }
+    $version = ($pg.Version | Where-Object { $_ } | Select-Object -First 1)
+    if (-not $version) { Write-Host "skip $packageId (no <Version>)"; continue }
+
+    $prev = Get-PreviousVersion $packageId $version
+    if (-not $prev) {
+        Write-Host "OK  $packageId $version — first release (no previous version to compare)."
+        continue
+    }
+
+    $cur = [version]($version -replace '[-+].*$', '')
+    $isMajorBump = $cur.Major -gt $prev.Major
+    $is0xMinorBump = ($cur.Major -eq 0 -and $prev.Major -eq 0 -and $cur.Minor -gt $prev.Minor)
+    $breaksAllowed = $isMajorBump -or ($is0xMinorBump -and $Allow0xMinorBreaks)
+
+    # Download + extract the previous package.
+    $work = Join-Path ([IO.Path]::GetTempPath()) "apicompat-$packageId-$prev"
+    if (Test-Path $work) { Remove-Item $work -Recurse -Force }
+    New-Item -ItemType Directory -Force -Path $work | Out-Null
+    $nupkg = Join-Path $work 'prev.nupkg'
+    $lid = $packageId.ToLowerInvariant()
+    Invoke-WebRequest -UseBasicParsing -Uri "$flat/$lid/$prev/$lid.$prev.nupkg" -OutFile $nupkg
+    Expand-Archive -Path $nupkg -DestinationPath $work -Force
+
+    $projDir = Split-Path $proj.FullName -Parent
+    $curLibRoot = Join-Path $projDir "bin/$Configuration"
+
+    # Compare every TFM present in BOTH the previous package and the current build.
+    $prevTfms = Get-ChildItem (Join-Path $work 'lib') -Directory -ErrorAction SilentlyContinue
+    foreach ($tfmDir in $prevTfms) {
+        $tfm = $tfmDir.Name
+        $prevDll = Join-Path $tfmDir.FullName "$packageId.dll"
+        $curDll = Join-Path $curLibRoot "$tfm/$packageId.dll"
+        if (-not (Test-Path $prevDll) -or -not (Test-Path $curDll)) { continue }
+
+        Write-Host "--- $packageId [$tfm]: $prev -> $version ---"
+        $raw = & apicompat --left $prevDll --right $curDll 2>&1
+        $text = ($raw | Out-String)
+
+        $breaks = $raw |
+            Where-Object { $_ -match 'CP[0-9]{4}' } |
+            Where-Object { $line = $_; -not ($suppressions | Where-Object { $line -like "*$_*" }) }
+
+        if ($breaks) {
+            if ($breaksAllowed) {
+                Write-Host "  ⚠️  $($breaks.Count) ABI break(s) — allowed for this bump (record intentional ones in compat-suppressions.txt):"
+                $breaks | ForEach-Object { Write-Host "     $_" }
+            }
+            else {
+                Write-Host "  ❌ $($breaks.Count) ABI break(s) in a non-major bump:"
+                $breaks | ForEach-Object { Write-Host "     $_" }
+                $breakingTotal += $breaks.Count
+            }
+        }
+        else {
+            Write-Host "  ✅ no breaking changes."
+        }
+    }
+}
+
+if ($breakingTotal -gt 0) {
+    Write-Error "❌ $breakingTotal unsuppressed ABI break(s) in a non-major release. Bump MAJOR or record intentional breaks in compat-suppressions.txt."
+    exit 1
+}
+Write-Host "✅ ApiCompat: no disallowed ABI breaks."

--- a/scripts/Check-ApiCompatibility.ps1
+++ b/scripts/Check-ApiCompatibility.ps1
@@ -44,8 +44,17 @@ if (Test-Path $SuppressionsFile) {
 
 function Get-PreviousVersion([string]$packageId, [string]$currentVersion) {
     $url = "$flat/$($packageId.ToLowerInvariant())/index.json"
-    try { $all = (Invoke-RestMethod -Uri $url -ErrorAction Stop).versions }
-    catch { return $null }   # 404 => package never published => first release
+    try {
+        $all = (Invoke-RestMethod -Uri $url -ErrorAction Stop).versions
+    }
+    catch {
+        # Only a genuine 404 means the package has never been published (first
+        # release). Any other failure (transient network / NuGet outage / 5xx)
+        # must NOT silently skip the ABI gate — surface it and fail.
+        $status = $_.Exception.Response.StatusCode.value__
+        if ($status -eq 404) { return $null }
+        throw "Failed to query NuGet for '$packageId' (HTTP $status): $($_.Exception.Message)"
+    }
     $cur = [version]($currentVersion -replace '[-+].*$', '')
     $prev = $all |
         Where-Object { $_ -notmatch '-' } |
@@ -100,7 +109,6 @@ foreach ($proj in $projects) {
 
         Write-Host "--- $packageId [$tfm]: $prev -> $version ---"
         $raw = & apicompat --left $prevDll --right $curDll 2>&1
-        $text = ($raw | Out-String)
 
         $breaks = $raw |
             Where-Object { $_ -match 'CP[0-9]{4}' } |


### PR DESCRIPTION
Closes #88.

## What
An ABI-compatibility gate for releases. `scripts/Check-ApiCompatibility.ps1` (called from a new `release.yaml` step) downloads each package's **previous** NuGet version and runs **Microsoft.DotNet.ApiCompat** over every shared TFM, failing a **non-major** release on an unsuppressed binary break. Complements PublicApiAnalyzers — ApiCompat catches binary/behavioural breaks (removed members, default/nullability flips) that a source-signature diff misses.

## Behaviour
- **SemVer-aware:** MAJOR may break ABI; MINOR/PATCH may not (0.x MINOR breaks gated by default, opt-out via `-Allow0xMinorBreaks`).
- **`compat-suppressions.txt`** records intentional/reviewed breaks (empty baseline; one ApiCompat id or message-substring per line).
- **First release handled:** a package with no previous NuGet version is skipped — so the brand-new `EntityFramework6` package doesn't error.
- **Multi-package + multi-TFM** automatically (iterates `src/**/*.csproj` × shared `lib/<tfm>`).

## Verification (local)
- Main package **0.1.1 → 0.2.0** across all 4 TFMs (net462, netstandard2.0/2.1, net10.0) → **no breaking changes** (the release was additive). Exit 0.
- `EntityFramework6 0.2.0` → correctly reported as first release, skipped.
- **Proved the gate fires:** a reversed compare emits `CP0001`/`CP0002` lines, which the script's `CP####` parser matches → a real break would fail.
- `release.yaml` passes actionlint + YAML validation; script runs end-to-end under pwsh.

## Fleet note
Fleet-wide thorough-review item; not in `repo-template` — recommend promoting to canonical.

## ⚠️ Merge note
Touches `release.yaml` (protected) → `Detect .NET Projects` guard fails by design → **needs maintainer admin-bypass**.