### PR TITLE
Integrate vNext → protected/vNext (thorough-review CI/tooling batch)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -253,7 +253,15 @@ jobs:
     name: "ReSharper InspectCode"
     runs-on: ubuntu-latest
     needs: detect-projects
-    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    # SAME-REPO PRs ONLY. Under pull_request_target this job checks out and BUILDS
+    # PR code while holding security-events: write — so it must never run for a
+    # fork (untrusted contributor). `github.repository` is always the base repo
+    # under pull_request_target, so the repo != repo-template check does NOT
+    # exclude forks; the head-repo comparison does.
+    if: >-
+      github.repository != 'Chris-Wolfgang/repo-template'
+      && needs.detect-projects.outputs.has-projects == 'true'
+      && github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 20
     permissions:
       contents: read
@@ -266,23 +274,31 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
           persist-credentials: false
 
+      - name: Fetch trusted analysis config from main
+        # pull_request_target hardening: don't let the PR's own analyzer config
+        # drive InspectCode. Overwrite the analysis-relevant files with main's
+        # versions before building (mirrors the other jobs' trusted-config fetch).
+        run: |
+          git fetch origin main:main-ref
+          for f in .editorconfig Directory.Build.props Directory.Build.targets; do
+            if git cat-file -e "main-ref:$f" 2>/dev/null; then
+              git checkout main-ref -- "$f"
+            fi
+          done
+          # .globalconfig / .ruleset (any path)
+          while IFS= read -r f; do
+            [ -n "$f" ] && git checkout main-ref -- "$f" 2>/dev/null || true
+          done < <(git ls-tree -r --name-only main-ref | grep -E '\.(globalconfig|ruleset)$' || true)
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
-      - name: Restore + Build (Release)
+      - name: Resolve solution
+        id: sln
         run: |
-          dotnet restore
-          dotnet build -c Release --no-restore
-
-      - name: Install JetBrains.ReSharper.GlobalTools
-        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
-
-      - name: Run InspectCode
-        run: |
-          # Find a solution to inspect. Prefer .slnx (new format) then .sln.
-          # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
+          # Prefer .slnx (new format) then .sln. Fail loudly if neither exists.
           SLN=$(ls *.slnx 2>/dev/null | head -n1)
           if [ -z "$SLN" ]; then
             SLN=$(ls *.sln 2>/dev/null | head -n1)
@@ -291,8 +307,23 @@ jobs:
             echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
             exit 1
           fi
-          echo "Inspecting: $SLN"
-          jb inspectcode "$SLN" \
+          echo "Solution: $SLN"
+          echo "sln=$SLN" >> "$GITHUB_OUTPUT"
+
+      - name: Restore + Build (Release)
+        # Build the resolved solution explicitly (not a bare `dotnet build`), so
+        # repos with more than one solution/project at the root don't fail on
+        # CLI disambiguation.
+        run: |
+          dotnet restore "${{ steps.sln.outputs.sln }}"
+          dotnet build "${{ steps.sln.outputs.sln }}" -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        run: |
+          jb inspectcode "${{ steps.sln.outputs.sln }}" \
             --output=inspect.sarif \
             --format=sarif \
             --severity=WARNING \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -241,9 +241,84 @@ jobs:
           fi
 
   # ============================================================================
+  # INSPECTCODE: JetBrains ReSharper InspectCode parallel to the test stages.
+  # Runs concurrently with Stage 1 / 2 / 3 (no `needs:` on a test job) so it
+  # doesn't extend wall-clock — typically 3–5 min vs the slowest stage.
+  # SARIF uploads to GitHub Code Scanning (Security tab + inline PR
+  # annotations). `error`-severity findings fail the job; `warning`-severity
+  # surfaces in Code Scanning but doesn't fail (gated by --severity=WARNING
+  # filter). Tune the noise floor via .DotSettings at the repo root.
+  # ============================================================================
+  inspectcode:
+    name: "ReSharper InspectCode"
+    runs-on: ubuntu-latest
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for upload-sarif
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore + Build (Release)
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        run: |
+          # Find a solution to inspect. Prefer .slnx (new format) then .sln.
+          # InspectCode requires SOMETHING solution-shaped — fail loudly if neither exists.
+          SLN=$(ls *.slnx 2>/dev/null | head -n1)
+          if [ -z "$SLN" ]; then
+            SLN=$(ls *.sln 2>/dev/null | head -n1)
+          fi
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln found at repo root — InspectCode needs one to run."
+            exit 1
+          fi
+          echo "Inspecting: $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        run: |
+          # SARIF level=error fails the job; warnings still upload (visible in
+          # Security → Code scanning) but don't gate merge — raise to `error`
+          # later when the noise floor is acceptable.
+          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count InspectCode error-severity finding(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No error-severity InspectCode findings."
+
+  # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
-  test-linux-core: 
+  test-linux-core:
     name: "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate"
     runs-on:  ubuntu-latest
     needs: detect-projects

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -375,6 +375,17 @@ jobs:
           dotnet restore
           dotnet build --no-restore --configuration Release
 
+      # ABI-compatibility gate (#88): diff each built package assembly against the
+      # previous version published on NuGet. Fails the release if a non-major bump
+      # introduces an unsuppressed binary break. Complements PublicApiAnalyzers,
+      # which only diffs source-level signatures.
+      - name: Check ABI compatibility (ApiCompat)
+        shell: pwsh
+        run: |
+          dotnet tool install -g Microsoft.DotNet.ApiCompat.Tool
+          $env:PATH += [IO.Path]::PathSeparator + (Join-Path $env:USERPROFILE '.dotnet/tools')
+          ./scripts/Check-ApiCompatibility.ps1 -Configuration Release
+
       - name: Pack NuGet packages
         id: check-packages
         shell: pwsh

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,8 @@ on:
     branches: [ main ]
 
 # Least-privilege default; the analysis job opts into the writes it needs.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:
@@ -36,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,57 @@
+# ============================================================================
+# OSSF Scorecard — automated security-posture scoring of the repo configuration
+# (branch protection, pinned deps, dangerous-workflow patterns, token
+# permissions, etc.). Complements CodeQL/DevSkim/InspectCode, which scan the
+# CODE; Scorecard scores the repo SETUP. Results publish to the Security tab
+# (SARIF) and to the public OpenSSF API so the README badge can render the score.
+# ============================================================================
+name: OSSF Scorecard
+
+on:
+  # Re-scan whenever branch protection changes (a key scored input).
+  branch_protection_rule:
+  # Weekly, plus on every push to main so the badge stays current.
+  schedule:
+    - cron: '27 5 * * 1'
+  push:
+    branches: [ main ]
+
+# Least-privilege default; the analysis job opts into the writes it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload the SARIF result to the code-scanning dashboard.
+      security-events: write
+      # Publish results to the public OpenSSF Scorecard API (drives the badge).
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the OpenSSF API — required for the README badge and for
+          # cross-repo trend data. Public repos only; publishes no source code.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -21,6 +21,9 @@ jobs:
   actionlint:
     name: actionlint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write   # reviewdog creates a Check run to surface annotations
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -30,7 +33,9 @@ jobs:
       - name: Run actionlint
         uses: reviewdog/action-actionlint@v1
         with:
-          reporter: github-pr-check
+          # github-check (not github-pr-check) so annotations are produced on
+          # both pull_request and push-to-main runs, not only in PR context.
+          reporter: github-check
           fail_level: error
 
   zizmor:

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -1,0 +1,77 @@
+# ============================================================================
+# Workflow Security — audits the GitHub Actions YAML itself (not the code).
+# actionlint catches syntax / expression / shell errors; zizmor audits for
+# workflow-level security issues (injection, over-broad permissions, dangerous
+# triggers, unpinned actions). Accepted findings are documented in
+# .github/zizmor.yml. Runs on `pull_request` (safe — no secrets, no PR code
+# executed in a privileged context) rather than `pull_request_target`.
+# ============================================================================
+name: Workflow Security
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          reporter: github-pr-check
+          fail_level: error
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # upload SARIF to code scanning
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run zizmor (SARIF)
+        id: zizmor
+        run: |
+          # Version-pinned for reproducibility. Config (.github/zizmor.yml) is
+          # auto-discovered. --min-severity=high so only high-severity findings
+          # gate; informational/low/medium still appear in Code Scanning.
+          set +e
+          pipx run zizmor==1.26.1 --persona=regular --min-severity=high \
+            --format=sarif .github/workflows/ > zizmor.sarif
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Upload SARIF to code-scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: zizmor.sarif
+
+      - name: Gate on high-severity findings
+        run: |
+          if [ "${{ steps.zizmor.outputs.exit }}" != "0" ]; then
+            echo "::error::zizmor found high-severity workflow issue(s) — see Security → Code scanning"
+            exit 1
+          fi
+          echo "✅ No high-severity zizmor findings."

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,23 @@
+# zizmor configuration — GitHub Actions workflow security audit.
+# https://docs.zizmor.sh/configuration/
+#
+# Accepted suppressions (reason required per the maintenance policy):
+#   - unpinned-uses:      the fleet pins actions to floating major-version TAGS
+#                         (actions/checkout@v7), not commit hashes — a deliberate
+#                         maintenance decision (repo-template #425). `ref-pin`
+#                         accepts a tag/branch ref, so tag pins are clean and only
+#                         a mutable-branch/no-ref pin is flagged.
+#   - dangerous-triggers: pr.yaml uses `pull_request_target` ON PURPOSE so the
+#                         workflow definition comes from main (a PR branch cannot
+#                         weaken its own CI). The risk is mitigated by the
+#                         "Detect .NET Projects" job, which fetches every trusted
+#                         config file from main and never checks out PR code into
+#                         a privileged context. Intentional and reviewed.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": ref-pin
+  dangerous-triggers:
+    ignore:
+      - pr.yaml

--- a/Extensions-Logging-Data.slnx
+++ b/Extensions-Logging-Data.slnx
@@ -53,6 +53,7 @@
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/Wolfgang.Extensions.Logging.Data.Tests.Integration.csproj" />
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj" />
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.csproj" />
+    <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/Wolfgang.Extensions.Logging.Data.Tests.Docs.csproj" />
   </Folder>
 </Solution>
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Extension methods on `ILogger` for logging `DbConnection`, `DbCommand`, and othe
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
 [![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github)](https://github.com/Chris-Wolfgang/Extensions-Logging-Data)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Chris-Wolfgang/Extensions-Logging-Data/badge)](https://scorecard.dev/viewer/?uri=github.com/Chris-Wolfgang/Extensions-Logging-Data)
 
 ---
 

--- a/compat-suppressions.txt
+++ b/compat-suppressions.txt
@@ -1,0 +1,4 @@
+# ABI-compatibility suppressions for scripts/Check-ApiCompatibility.ps1.
+# One accepted/intentional break per line — an ApiCompat id (e.g. CP0002) or a
+# substring of the finding message. Only add entries for breaks that are
+# deliberate (typically in a MAJOR release), with the reason in the commit/PR.

--- a/scripts/Check-ApiCompatibility.ps1
+++ b/scripts/Check-ApiCompatibility.ps1
@@ -1,0 +1,130 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    ABI-compatibility gate: compares each freshly-built src package assembly
+    against the previous version published on NuGet using Microsoft.DotNet.ApiCompat,
+    and fails when a NON-major version bump introduces a breaking change.
+
+.DESCRIPTION
+    Complements PublicApiAnalyzers (which diffs signatures at source level). ApiCompat
+    catches binary/behavioural breaks — default-value changes, nullability flips,
+    removed members a consumer's compiled assembly binds to at runtime.
+
+    Per SemVer: MAJOR may break ABI; MINOR/PATCH may not. For a 0.x package every
+    bump is treated as potentially-breaking-allowed only when the MAJOR component is 0
+    AND the caller opts in via -Allow0xMinorBreaks (0.x MINOR bumps are permitted to
+    break per SemVer's 0.x clause). By default 0.x MINOR/PATCH breaks are reported and
+    fail, which is the safer stance for a library approaching 1.0.
+
+    Intentional, reviewed breaks are recorded one-per-line in compat-suppressions.txt
+    (an ApiCompat suppression id or a substring of the message) so they don't recur
+    silently.
+
+.NOTES
+    Requires the Microsoft.DotNet.ApiCompat.Tool global tool on PATH (installed by the
+    release workflow). Runnable locally: pwsh scripts/Check-ApiCompatibility.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$Configuration = 'Release',
+    [string]$SuppressionsFile = "$PSScriptRoot/../compat-suppressions.txt",
+    [switch]$Allow0xMinorBreaks
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Resolve-Path "$PSScriptRoot/.."
+$flat = 'https://api.nuget.org/v3-flatcontainer'
+
+$suppressions = @()
+if (Test-Path $SuppressionsFile) {
+    $suppressions = Get-Content $SuppressionsFile |
+        Where-Object { $_ -and -not $_.TrimStart().StartsWith('#') } |
+        ForEach-Object { $_.Trim() }
+}
+
+function Get-PreviousVersion([string]$packageId, [string]$currentVersion) {
+    $url = "$flat/$($packageId.ToLowerInvariant())/index.json"
+    try { $all = (Invoke-RestMethod -Uri $url -ErrorAction Stop).versions }
+    catch { return $null }   # 404 => package never published => first release
+    $cur = [version]($currentVersion -replace '[-+].*$', '')
+    $prev = $all |
+        Where-Object { $_ -notmatch '-' } |
+        ForEach-Object { [version]($_ -replace '[-+].*$', '') } |
+        Where-Object { $_ -lt $cur } |
+        Sort-Object |
+        Select-Object -Last 1
+    return $prev
+}
+
+$breakingTotal = 0
+$projects = Get-ChildItem -Path (Join-Path $repoRoot 'src') -Recurse -Filter '*.csproj'
+
+foreach ($proj in $projects) {
+    [xml]$xml = Get-Content $proj.FullName
+    $pg = $xml.Project.PropertyGroup
+    $packageId = ($pg.PackageId | Where-Object { $_ } | Select-Object -First 1)
+    if (-not $packageId) { $packageId = [IO.Path]::GetFileNameWithoutExtension($proj.Name) }
+    $version = ($pg.Version | Where-Object { $_ } | Select-Object -First 1)
+    if (-not $version) { Write-Host "skip $packageId (no <Version>)"; continue }
+
+    $prev = Get-PreviousVersion $packageId $version
+    if (-not $prev) {
+        Write-Host "OK  $packageId $version — first release (no previous version to compare)."
+        continue
+    }
+
+    $cur = [version]($version -replace '[-+].*$', '')
+    $isMajorBump = $cur.Major -gt $prev.Major
+    $is0xMinorBump = ($cur.Major -eq 0 -and $prev.Major -eq 0 -and $cur.Minor -gt $prev.Minor)
+    $breaksAllowed = $isMajorBump -or ($is0xMinorBump -and $Allow0xMinorBreaks)
+
+    # Download + extract the previous package.
+    $work = Join-Path ([IO.Path]::GetTempPath()) "apicompat-$packageId-$prev"
+    if (Test-Path $work) { Remove-Item $work -Recurse -Force }
+    New-Item -ItemType Directory -Force -Path $work | Out-Null
+    $nupkg = Join-Path $work 'prev.nupkg'
+    $lid = $packageId.ToLowerInvariant()
+    Invoke-WebRequest -UseBasicParsing -Uri "$flat/$lid/$prev/$lid.$prev.nupkg" -OutFile $nupkg
+    Expand-Archive -Path $nupkg -DestinationPath $work -Force
+
+    $projDir = Split-Path $proj.FullName -Parent
+    $curLibRoot = Join-Path $projDir "bin/$Configuration"
+
+    # Compare every TFM present in BOTH the previous package and the current build.
+    $prevTfms = Get-ChildItem (Join-Path $work 'lib') -Directory -ErrorAction SilentlyContinue
+    foreach ($tfmDir in $prevTfms) {
+        $tfm = $tfmDir.Name
+        $prevDll = Join-Path $tfmDir.FullName "$packageId.dll"
+        $curDll = Join-Path $curLibRoot "$tfm/$packageId.dll"
+        if (-not (Test-Path $prevDll) -or -not (Test-Path $curDll)) { continue }
+
+        Write-Host "--- $packageId [$tfm]: $prev -> $version ---"
+        $raw = & apicompat --left $prevDll --right $curDll 2>&1
+        $text = ($raw | Out-String)
+
+        $breaks = $raw |
+            Where-Object { $_ -match 'CP[0-9]{4}' } |
+            Where-Object { $line = $_; -not ($suppressions | Where-Object { $line -like "*$_*" }) }
+
+        if ($breaks) {
+            if ($breaksAllowed) {
+                Write-Host "  ⚠️  $($breaks.Count) ABI break(s) — allowed for this bump (record intentional ones in compat-suppressions.txt):"
+                $breaks | ForEach-Object { Write-Host "     $_" }
+            }
+            else {
+                Write-Host "  ❌ $($breaks.Count) ABI break(s) in a non-major bump:"
+                $breaks | ForEach-Object { Write-Host "     $_" }
+                $breakingTotal += $breaks.Count
+            }
+        }
+        else {
+            Write-Host "  ✅ no breaking changes."
+        }
+    }
+}
+
+if ($breakingTotal -gt 0) {
+    Write-Error "❌ $breakingTotal unsuppressed ABI break(s) in a non-major release. Bump MAJOR or record intentional breaks in compat-suppressions.txt."
+    exit 1
+}
+Write-Host "✅ ApiCompat: no disallowed ABI breaks."

--- a/scripts/Check-ApiCompatibility.ps1
+++ b/scripts/Check-ApiCompatibility.ps1
@@ -44,8 +44,17 @@ if (Test-Path $SuppressionsFile) {
 
 function Get-PreviousVersion([string]$packageId, [string]$currentVersion) {
     $url = "$flat/$($packageId.ToLowerInvariant())/index.json"
-    try { $all = (Invoke-RestMethod -Uri $url -ErrorAction Stop).versions }
-    catch { return $null }   # 404 => package never published => first release
+    try {
+        $all = (Invoke-RestMethod -Uri $url -ErrorAction Stop).versions
+    }
+    catch {
+        # Only a genuine 404 means the package has never been published (first
+        # release). Any other failure (transient network / NuGet outage / 5xx)
+        # must NOT silently skip the ABI gate — surface it and fail.
+        $status = $_.Exception.Response.StatusCode.value__
+        if ($status -eq 404) { return $null }
+        throw "Failed to query NuGet for '$packageId' (HTTP $status): $($_.Exception.Message)"
+    }
     $cur = [version]($currentVersion -replace '[-+].*$', '')
     $prev = $all |
         Where-Object { $_ -notmatch '-' } |
@@ -100,7 +109,6 @@ foreach ($proj in $projects) {
 
         Write-Host "--- $packageId [$tfm]: $prev -> $version ---"
         $raw = & apicompat --left $prevDll --right $curDll 2>&1
-        $text = ($raw | Out-String)
 
         $breaks = $raw |
             Where-Object { $_ -match 'CP[0-9]{4}' } |

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/AssemblyInfo.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
+// This assembly's code is test scaffolding (a Roslyn doc-example compiler), not
+// shippable surface — exclude it from the per-module coverage gate.
+[assembly: ExcludeFromCodeCoverage]

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/DocExampleCompilationTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/DocExampleCompilationTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Wolfgang.Extensions.Logging.Data.Tests.Docs;
+
+/// <summary>
+/// Compiles every <c>&lt;example&gt;&lt;code&gt;</c> block found in the XML-doc comments of
+/// the source, catching "documentation rot" — an example that stops compiling because the
+/// API it demonstrates was renamed, removed, or changed. Each block is wrapped in a minimal
+/// async harness (ambient <c>logger</c> / <c>connection</c> / <c>connectionString</c> /
+/// <c>command</c> are injected only when a block uses but does not declare them) and compiled
+/// with Roslyn against the same reference set the test process runs on.
+/// </summary>
+public class DocExampleCompilationTests
+{
+    private static readonly (string Name, string Declaration)[] AmbientCandidates =
+    {
+        ("logger", "Microsoft.Extensions.Logging.ILogger logger = null!;"),
+        ("connectionString", "string connectionString = null!;"),
+        ("connection", "System.Data.Common.DbConnection connection = null!;"),
+        ("command", "System.Data.Common.DbCommand command = null!;"),
+    };
+
+    public static IEnumerable<object[]> Examples()
+    {
+        var srcDir = FindSourceDirectory();
+        foreach (var file in Directory.EnumerateFiles(srcDir, "*.cs", SearchOption.AllDirectories))
+        {
+            var text = File.ReadAllText(file);
+            var i = 0;
+            foreach (var code in ExtractCodeBlocks(text))
+            {
+                i++;
+                yield return new object[] { $"{Path.GetFileName(file)}#{i}", code };
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Examples))]
+    public void DocExample_compiles(string id, string code)
+    {
+        _ = id;
+        var program = BuildProgram(code);
+
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Where(p => p.Length > 0)
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create
+        (
+            "DocExamples",
+            new[] { CSharpSyntaxTree.ParseText(program) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable)
+        );
+
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => d.ToString())
+            .ToList();
+
+        Assert.True
+        (
+            errors.Count == 0,
+            $"Doc example {id} does not compile:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}{Environment.NewLine}--- generated ---{Environment.NewLine}{program}"
+        );
+    }
+
+    [Fact]
+    public void At_least_one_example_was_discovered()
+    {
+        // Guards against the extraction silently finding nothing (e.g. a regex or path
+        // regression) — which would make DocExample_compiles a vacuous green.
+        Assert.NotEmpty(Examples());
+    }
+
+    private static string BuildProgram(string snippet)
+    {
+        var declared = new HashSet<string>(
+            Regex.Matches(snippet, @"\b(?:using\s+)?var\s+(\w+)\s*=")
+                 .Select(m => m.Groups[1].Value));
+
+        var ambient = new StringBuilder();
+        foreach (var (name, declaration) in AmbientCandidates)
+        {
+            var usesIt = Regex.IsMatch(snippet, $@"\b{name}\b");
+            if (usesIt && !declared.Contains(name))
+            {
+                ambient.Append("        ").Append(declaration).Append('\n');
+            }
+        }
+
+        return
+            "using System;\n" +
+            "using System.Collections.Generic;\n" +
+            "using System.Data.Common;\n" +
+            "using System.Data.SqlClient;\n" +
+            "using System.Threading.Tasks;\n" +
+            "using Microsoft.Extensions.Logging;\n" +
+            "using Wolfgang.Extensions.Logging.Data;\n" +
+            "internal class __DocExampleHarness\n{\n" +
+            "    private async Task __RunAsync()\n    {\n" +
+            ambient +
+            snippet + "\n" +
+            "        await Task.CompletedTask;\n" +
+            "    }\n}\n";
+    }
+
+    private static IEnumerable<string> ExtractCodeBlocks(string fileText)
+    {
+        // Match a <code> ... </code> region inside a run of `///` comment lines.
+        foreach (Match m in Regex.Matches(fileText, @"///\s*<code>\s*\r?\n(?<body>.*?)///\s*</code>", RegexOptions.Singleline))
+        {
+            var body = m.Groups["body"].Value;
+            var lines = body.Split('\n')
+                .Select(l => l.TrimEnd('\r'))
+                .Select(StripDocPrefix)
+                .ToList();
+            var code = WebUtility.HtmlDecode(string.Join("\n", lines)).Trim();
+            if (code.Length > 0)
+            {
+                yield return code;
+            }
+        }
+    }
+
+    private static string StripDocPrefix(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.StartsWith("///", StringComparison.Ordinal))
+        {
+            trimmed = trimmed.Substring(3);
+            if (trimmed.StartsWith(" ", StringComparison.Ordinal))
+            {
+                trimmed = trimmed.Substring(1);
+            }
+            return trimmed;
+        }
+        return line;
+    }
+
+    private static string FindSourceDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "Wolfgang.Extensions.Logging.Data");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate src/Wolfgang.Extensions.Logging.Data walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/DocExampleCompilationTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/DocExampleCompilationTests.cs
@@ -33,6 +33,13 @@ public class DocExampleCompilationTests
         var srcDir = FindSourceDirectory();
         foreach (var file in Directory.EnumerateFiles(srcDir, "*.cs", SearchOption.AllDirectories))
         {
+            // Skip build outputs — bin/obj can contain generated .cs (and copied
+            // sources) that would be scanned needlessly.
+            if (IsUnderBuildOutput(file))
+            {
+                continue;
+            }
+
             var text = File.ReadAllText(file);
             var i = 0;
             foreach (var code in ExtractCodeBlocks(text))
@@ -47,7 +54,6 @@ public class DocExampleCompilationTests
     [MemberData(nameof(Examples))]
     public void DocExample_compiles(string id, string code)
     {
-        _ = id;
         var program = BuildProgram(code);
 
         var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
@@ -147,6 +153,13 @@ public class DocExampleCompilationTests
             return trimmed;
         }
         return line;
+    }
+
+    private static bool IsUnderBuildOutput(string path)
+    {
+        var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return parts.Any(p => string.Equals(p, "bin", StringComparison.OrdinalIgnoreCase)
+                           || string.Equals(p, "obj", StringComparison.OrdinalIgnoreCase));
     }
 
     private static string FindSourceDirectory()

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/Wolfgang.Extensions.Logging.Data.Tests.Docs.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/Wolfgang.Extensions.Logging.Data.Tests.Docs.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Single modern TFM: this project compiles doc examples with Roslyn, which
+         needs net472+/net8+. No need to run it on the .NET Framework matrix. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+
+    <!-- Referenced so the types the doc examples use are on the compile reference
+         set (via TRUSTED_PLATFORM_ASSEMBLIES): the package itself, the logging
+         abstractions, and SqlConnection (used by the LogDbConnection examples). -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.Logging.Data\Wolfgang.Extensions.Logging.Data.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Stage 2 of the release flow: **feature → vNext → protected/vNext → main**.

Rolls up the merged thorough-review batch (all CI/tooling/test/docs — **no `src/` change**, so no NuGet release):
- **#151** ReSharper InspectCode gate (hardened: fork guard + trusted-config fetch + explicit build)
- **#153** OSSF Scorecard workflow + badge
- **#154** workflow-security audit (actionlint + zizmor)
- **#155** XML-doc `<example>` rot detection (Roslyn compile test)
- **#156** ApiCompat ABI-compatibility release gate

Base is `protected/vNext` (not `main`), so the `Detect .NET Projects` guard doesn't run here — this PR can merge normally. The protected-file admin-bypass happens on the next hop, `protected/vNext → main`.