### PR TITLE
Verify + document Trim/Native AOT compatibility (#94)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -353,6 +353,67 @@ jobs:
           echo "✅ No error-severity InspectCode findings."
 
   # ============================================================================
+  # AOT SMOKE: publish a Native-AOT + trimmed consumer of the library and run it.
+  # The trim/AOT analyzers (TreatWarningsAsErrors) fail the build on any regression
+  # to the AOT-safe surface; running the native binary catches runtime breaks
+  # (MissingMethod / NotSupported / silent no-op). Parallel to the test stages.
+  # ============================================================================
+  aot-smoke:
+    name: "Native AOT smoke"
+    runs-on: ubuntu-latest
+    needs: detect-projects
+    # Same-repo PRs only — builds PR code under pull_request_target (see the
+    # inspectcode job for the rationale).
+    if: >-
+      github.repository != 'Chris-Wolfgang/repo-template'
+      && needs.detect-projects.outputs.has-projects == 'true'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install Native AOT prerequisites
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Find the AOT smoke project
+        id: smoke
+        run: |
+          PROJ=$(find . -name '*.AotSmoke.csproj' | head -n1)
+          if [ -z "$PROJ" ]; then
+            echo "No *.AotSmoke.csproj found — skipping."
+            echo "found=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Smoke project: $PROJ"
+            echo "found=$PROJ" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish Native AOT (trim + AOT analyzers gate the build)
+        if: steps.smoke.outputs.found != ''
+        run: dotnet publish "${{ steps.smoke.outputs.found }}" -c Release -r linux-x64
+
+      - name: Run the published native binary
+        if: steps.smoke.outputs.found != ''
+        run: |
+          BIN=$(find "$(dirname "${{ steps.smoke.outputs.found }}")/bin" -type f -name '*.AotSmoke' -path '*publish*' | head -n1)
+          if [ -z "$BIN" ]; then
+            echo "::error::Native AOT binary not produced."
+            exit 1
+          fi
+          echo "Running: $BIN"
+          "$BIN"
+
+  # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
   test-linux-core:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Trim / Native AOT compatibility.** The `LogDbConnection`, `LogDbCommand`,
+  and dictionary-based `LogCommandText` surface is verified trim- and AOT-safe by
+  a `PublishAot` + `PublishTrimmed` smoke consumer run in CI. (#94)
+
 ### Changed
+
+- The **anonymous-object `LogCommandText(..., object parameters, ...)` overloads
+  are now marked `[RequiresUnreferencedCode]`** — they reflect over the runtime
+  type's properties, which the trimmer cannot preserve. Callers in trimmed /
+  Native AOT apps get an `IL2026` warning; use the
+  `IReadOnlyDictionary<string, object?>` overload instead. No change for
+  non-trimmed consumers. (#94)
 
 ### Deprecated
 

--- a/Extensions-Logging-Data.slnx
+++ b/Extensions-Logging-Data.slnx
@@ -54,6 +54,7 @@
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj" />
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.csproj" />
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/Wolfgang.Extensions.Logging.Data.Tests.Docs.csproj" />
+    <Project Path="tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Wolfgang.Extensions.Logging.Data.AotSmoke.csproj" />
   </Folder>
 </Solution>
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ logger.LogDbConnection(connection, LogLevel.Debug);
 
 `DbCommand` logging is also available via `ILogger.LogCommandText(...)` (command text + parameter snapshot with opt-in redaction) and `ILogger.LogDbCommand(DbCommand, ...)` (logs a live command directly). The library is intentionally narrow and grows one type at a time as needed.
 
+> **Trimming / Native AOT:** `LogDbConnection`, `LogDbCommand`, and the `IReadOnlyDictionary<string, object?>` overloads of `LogCommandText` are trim- and AOT-safe (verified by a `PublishAot` smoke in CI). The **anonymous-object** `LogCommandText(..., object parameters, ...)` overloads reflect over the parameter's runtime properties and are marked `[RequiresUnreferencedCode]` — in trimmed/AOT apps use the dictionary overload instead.
+
 ---
 
 ## 🪵 Entity Framework 6 companion

--- a/src/Wolfgang.Extensions.Logging.Data/Compatibility/TrimAnnotations.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/Compatibility/TrimAnnotations.cs
@@ -1,0 +1,34 @@
+// Polyfill for RequiresUnreferencedCodeAttribute, which the .NET 5+ BCL provides but
+// the older target frameworks (net462, netstandard2.0, netstandard2.1) do not. The IL
+// trimmer / Native AOT compiler match this attribute by full type name, so an internal
+// definition with the canonical name is recognized exactly as the framework type would
+// be. On net5.0+ (incl. net10.0) the real BCL type is used and this file compiles away.
+#if !NET5_0_OR_GREATER
+
+#pragma warning disable MA0048 // File name must match type name — this is a framework polyfill.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that the marked method uses functionality (here, reflection over a runtime
+    /// type's members) that cannot be statically analysed by the trimmer, so calling it from
+    /// a trimmed / Native AOT application is not guaranteed to be safe. Polyfill of the .NET 5+
+    /// framework attribute for older target frameworks.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false)]
+    internal sealed class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        public RequiresUnreferencedCodeAttribute(string message)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+
+        public string? Url { get; set; }
+    }
+}
+
+#pragma warning restore MA0048
+
+#endif

--- a/src/Wolfgang.Extensions.Logging.Data/DbCommandLoggerExtensions.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/DbCommandLoggerExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
@@ -43,6 +44,11 @@ public static class DbCommandLoggerExtensions
         "DbCommand CommandText={CommandText} Parameters={Parameters}";
 
     private const string RedactedValue = "***";
+
+    private const string ReflectionParametersTrimMessage =
+        "The anonymous-object parameter overload reflects over the runtime type's public " +
+        "properties, which the trimmer cannot statically preserve. In trimmed / Native AOT " +
+        "applications, pass an IReadOnlyDictionary<string, object?> instead.";
 
     /// <summary>
     /// Per-type cache of "read the public properties of an instance of this type into a
@@ -201,6 +207,7 @@ public static class DbCommandLoggerExtensions
     ///     new[] { "password" });
     /// </code>
     /// </example>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     public static void LogCommandText(this ILogger logger, string commandText, object parameters)
     {
         LogCommandText(logger, commandText, ToDictionary(parameters), Array.Empty<string>(), LogLevel.Information);
@@ -220,6 +227,7 @@ public static class DbCommandLoggerExtensions
     /// Thrown when <paramref name="logger"/>, <paramref name="commandText"/>, or
     /// <paramref name="parameters"/> is <see langword="null"/>.
     /// </exception>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     public static void LogCommandText(this ILogger logger, string commandText, object parameters, LogLevel level)
     {
         LogCommandText(logger, commandText, ToDictionary(parameters), Array.Empty<string>(), level);
@@ -244,6 +252,7 @@ public static class DbCommandLoggerExtensions
     /// <paramref name="parameters"/>, or <paramref name="excludedParameterNames"/> is
     /// <see langword="null"/>.
     /// </exception>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     public static void LogCommandText(this ILogger logger, string commandText, object parameters, IEnumerable<string> excludedParameterNames)
     {
         LogCommandText(logger, commandText, ToDictionary(parameters), excludedParameterNames, LogLevel.Information);
@@ -269,6 +278,7 @@ public static class DbCommandLoggerExtensions
     /// <paramref name="parameters"/>, or <paramref name="excludedParameterNames"/> is
     /// <see langword="null"/>.
     /// </exception>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     public static void LogCommandText(this ILogger logger, string commandText, object parameters, IEnumerable<string> excludedParameterNames, LogLevel level)
     {
         LogCommandText(logger, commandText, ToDictionary(parameters), excludedParameterNames, level);
@@ -411,6 +421,7 @@ public static class DbCommandLoggerExtensions
     /// <param name="parameters">The object to read. Must not be <see langword="null"/>.</param>
     /// <returns>A dictionary of property name to value.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameters"/> is <see langword="null"/>.</exception>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     internal static IReadOnlyDictionary<string, object?> ToDictionary(object parameters)
     {
         if (parameters is null)
@@ -436,6 +447,7 @@ public static class DbCommandLoggerExtensions
     /// Builds a delegate that reads the public readable instance properties of objects of the
     /// given <paramref name="type"/> into a dictionary. Called once per type via the cache.
     /// </summary>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     private static Func<object, IReadOnlyDictionary<string, object?>> BuildPropertyReader(Type type)
     {
         var properties = type

--- a/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Fakes.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Fakes.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data.AotSmoke;
+
+/// <summary>Counts log entries so the smoke can assert no call silently no-ops.</summary>
+internal sealed class CountingLogger : ILogger
+{
+    public int Count { get; private set; }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        _ = formatter(state, exception);   // render the template so any format break surfaces
+        Count++;
+    }
+}
+
+
+/// <summary>Minimal in-memory <see cref="DbConnection"/> — no provider, so the smoke's trim/AOT result is attributable to the library alone.</summary>
+internal sealed class FakeDbConnection : DbConnection
+{
+    [AllowNull]
+    public override string ConnectionString { get; set; } = "Server=localhost;Database=Test;User Id=sa;Password=secret";
+
+    public override string Database => "Test";
+
+    public override string DataSource => "localhost";
+
+    public override string ServerVersion => "1.0";
+
+    public override ConnectionState State => ConnectionState.Closed;
+
+    public override void ChangeDatabase(string databaseName) { }
+
+    public override void Close() { }
+
+    public override void Open() { }
+
+    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new NotSupportedException();
+
+    protected override DbCommand CreateDbCommand() => new FakeDbCommand { Connection = this };
+}
+
+
+internal sealed class FakeDbCommand : DbCommand
+{
+    private readonly FakeParameterCollection _parameters = new();
+
+    [AllowNull]
+    public override string CommandText { get; set; } = string.Empty;
+
+    public override int CommandTimeout { get; set; }
+
+    public override CommandType CommandType { get; set; }
+
+    public override bool DesignTimeVisible { get; set; }
+
+    public override UpdateRowSource UpdatedRowSource { get; set; }
+
+    protected override DbConnection? DbConnection { get; set; }
+
+    protected override DbParameterCollection DbParameterCollection => _parameters;
+
+    protected override DbTransaction? DbTransaction { get; set; }
+
+    public override void Cancel() { }
+
+    public override int ExecuteNonQuery() => throw new NotSupportedException();
+
+    public override object? ExecuteScalar() => throw new NotSupportedException();
+
+    public override void Prepare() { }
+
+    protected override DbParameter CreateDbParameter() => new FakeParameter();
+
+    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => throw new NotSupportedException();
+}
+
+
+internal sealed class FakeParameter : DbParameter
+{
+    public override DbType DbType { get; set; }
+
+    public override ParameterDirection Direction { get; set; }
+
+    public override bool IsNullable { get; set; }
+
+    [AllowNull]
+    public override string ParameterName { get; set; } = string.Empty;
+
+    public override int Size { get; set; }
+
+    [AllowNull]
+    public override string SourceColumn { get; set; } = string.Empty;
+
+    public override bool SourceColumnNullMapping { get; set; }
+
+    [AllowNull]
+    public override object Value { get; set; }
+
+    public override void ResetDbType() { }
+}
+
+
+internal sealed class FakeParameterCollection : DbParameterCollection
+{
+    private readonly List<DbParameter> _items = new();
+
+    public override int Count => _items.Count;
+
+    public override object SyncRoot => _items;
+
+    public override int Add(object value)
+    {
+        _items.Add((DbParameter)value);
+        return _items.Count - 1;
+    }
+
+    public override IEnumerator GetEnumerator() => _items.GetEnumerator();
+
+    protected override DbParameter GetParameter(int index) => _items[index];
+
+    protected override DbParameter GetParameter(string parameterName) => throw new NotSupportedException();
+
+    public override void AddRange(Array values) => throw new NotSupportedException();
+
+    public override void Clear() => _items.Clear();
+
+    public override bool Contains(object value) => throw new NotSupportedException();
+
+    public override bool Contains(string value) => throw new NotSupportedException();
+
+    public override void CopyTo(Array array, int index) => throw new NotSupportedException();
+
+    public override int IndexOf(object value) => throw new NotSupportedException();
+
+    public override int IndexOf(string parameterName) => throw new NotSupportedException();
+
+    public override void Insert(int index, object value) => throw new NotSupportedException();
+
+    public override void Remove(object value) => throw new NotSupportedException();
+
+    public override void RemoveAt(int index) => throw new NotSupportedException();
+
+    public override void RemoveAt(string parameterName) => throw new NotSupportedException();
+
+    protected override void SetParameter(int index, DbParameter value) => throw new NotSupportedException();
+
+    protected override void SetParameter(string parameterName, DbParameter value) => throw new NotSupportedException();
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Program.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Program.cs
@@ -1,0 +1,47 @@
+// Native AOT / trimming smoke test for the AOT-safe public surface of
+// Wolfgang.Extensions.Logging.Data. Published with PublishAot + PublishTrimmed
+// (see the .csproj) and run by CI: a trim/AOT-unsafe regression makes the
+// analyzers warn (TreatWarningsAsErrors → build fails), and a runtime break
+// (MissingMethodException / NotSupportedException / silent no-op) makes this
+// program exit non-zero.
+//
+// The anonymous-object LogCommandText overloads are DELIBERATELY not exercised
+// here: they reflect over the parameter's runtime type and are marked
+// [RequiresUnreferencedCode] — documented as not AOT/trim-safe. The
+// IReadOnlyDictionary overloads are the AOT-safe equivalent and are covered.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data;
+using Wolfgang.Extensions.Logging.Data.AotSmoke;
+
+var logger = new CountingLogger();
+
+using var connection = new FakeDbConnection();
+logger.LogDbConnection(connection);
+logger.LogDbConnection(connection, LogLevel.Debug);
+
+using var command = connection.CreateCommand();
+command.CommandText = "SELECT * FROM Users WHERE Id = @id AND Pw = @password";
+logger.LogDbCommand(command);
+logger.LogDbCommand(command, LogLevel.Debug);
+logger.LogDbCommand(command, new[] { "password" });
+logger.LogDbCommand(command, new[] { "password" }, LogLevel.Debug);
+
+var parameters = new Dictionary<string, object?> { ["@id"] = 1, ["@password"] = "secret" };
+logger.LogCommandText("SELECT ...", parameters);
+logger.LogCommandText("SELECT ...", parameters, LogLevel.Debug);
+logger.LogCommandText("SELECT ...", parameters, new[] { "password" });
+logger.LogCommandText("SELECT ...", parameters, new[] { "password" }, LogLevel.Debug);
+
+// 10 AOT-safe calls above — each must produce exactly one log entry. A silent
+// no-op (e.g. trimmed members) would drop the count.
+const int expected = 10;
+if (logger.Count != expected)
+{
+    System.Console.Error.WriteLine($"FAIL: expected {expected} log entries, got {logger.Count}.");
+    return 1;
+}
+
+System.Console.WriteLine($"OK: AOT-safe surface produced {logger.Count} log entries under Native AOT.");
+return 0;

--- a/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Wolfgang.Extensions.Logging.Data.AotSmoke.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Wolfgang.Extensions.Logging.Data.AotSmoke.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+
+    <!-- The whole point of this project: enable the trim + Native AOT analyzers so
+         any trim/AOT regression in the library's AOT-safe surface fails the build,
+         and let `dotnet publish` produce a real native binary the CI step runs. -->
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <IsPackable>false</IsPackable>
+    <!-- Not a test project (no test SDK) — it is a compile+publish+run smoke. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.Logging.Data\Wolfgang.Extensions.Logging.Data.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+  </ItemGroup>
+</Project>

--- a/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Wolfgang.Extensions.Logging.Data.AotSmoke.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Wolfgang.Extensions.Logging.Data.AotSmoke.csproj
@@ -10,6 +10,9 @@
          any trim/AOT regression in the library's AOT-safe surface fails the build,
          and let `dotnet publish` produce a real native binary the CI step runs. -->
     <PublishAot>true</PublishAot>
+    <!-- PublishAot implies trimming, but set it explicitly so the project file
+         matches the documented intent and the trim analyzers are unambiguous. -->
+    <PublishTrimmed>true</PublishTrimmed>
     <IsAotCompatible>true</IsAotCompatible>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
Refs #94. Targets `vNext` (new release cycle).

## What
Makes the library's trim/AOT story explicit and **verified in CI**:

- **AOT-safe surface** — `LogDbConnection`, `LogDbCommand`, and the `IReadOnlyDictionary<string, object?>` overloads of `LogCommandText` are trim/AOT-clean.
- **The anonymous-object `LogCommandText(..., object parameters, ...)` overloads are marked `[RequiresUnreferencedCode]`** — they reflect over the runtime type's public properties (`Type.GetProperties`), which the trimmer can't preserve. Trimmed/AOT callers get `IL2026`; non-trimmed consumers are unaffected.

## Why not `[DynamicallyAccessedMembers]`?
Tried it first — it's **invalid here**: `IL2098`, DAM can only annotate `Type`/`string` parameters, not an `object`. There's no annotation that makes reflecting over an arbitrary object's properties trim-safe, so `[RequiresUnreferencedCode]` (honest "not safe") is the correct treatment. `RequiresUnreferencedCodeAttribute` is polyfilled for net462/netstandard2.0/2.1 (net5+ uses the BCL type).

## The smoke
`tests/Wolfgang.Extensions.Logging.Data.AotSmoke` — a console consumer with `PublishAot` + `PublishTrimmed` + `IsAotCompatible` + `TreatWarningsAsErrors`. Exercises **every AOT-safe method** against a self-contained fake `DbConnection`/`DbCommand` (no provider, so any warning is the library's), and asserts 10 log entries (a trimmed-away member would drop the count). A new **`aot-smoke` CI job** in `pr.yaml` installs the AOT toolchain, publishes the **native binary** (trim/AOT analyzers gate the build), and runs it.

## Verification (local)
- Library builds clean across all 4 TFMs.
- Safe-surface trim publish → **0 IL warnings**; the object-overload correctly emits **IL2026** (contract works).
- Smoke builds AOT-analyzer-clean + runs (`OK: ... 10 log entries`).
- Tests: **Unit 94 / EF6 29 / Docs 6** pass. Full solution + actionlint + zizmor clean.

## Acceptance criteria (#94)
✅ PublishAot+PublishTrimmed consumer · ✅ calls every (AOT-safe) public method + runs without NotSupported/silent-noop · ✅ documented suppression (`[RequiresUnreferencedCode]` on the reflection overloads, dictionary overload = the safe path) · ✅ runs on `pr.yaml`.