### PR TITLE
docs: ADRs + DR runbook + migration convention + reproducible-build verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 - **API Documentation:** https://Chris-Wolfgang.github.io/Extensions-Logging-Data/
 - **CHANGELOG:** [CHANGELOG.md](CHANGELOG.md)
 - **Contributing Guide:** [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Architecture Decision Records:** [docs/adr/](docs/adr/README.md)
+- **Reproducible builds (independent verification):** [docs/REPRODUCIBLE-BUILDS.md](docs/REPRODUCIBLE-BUILDS.md)
+- **Migration guides:** [docs/migrations/](docs/migrations/README.md)
+- **Disaster recovery runbook:** [docs/DISASTER-RECOVERY.md](docs/DISASTER-RECOVERY.md)
 - **DocFX Version Picker Troubleshooting:** [docs/DOCFX-VERSION-PICKER.md](docs/DOCFX-VERSION-PICKER.md)
 
 ---

--- a/docs/DISASTER-RECOVERY.md
+++ b/docs/DISASTER-RECOVERY.md
@@ -50,9 +50,12 @@ then eradicate, then communicate).
 ## 4. Communicate
 
 - If a **malicious package version shipped**: open a security advisory on the repo,
-  contact **NuGet support** (<https://www.nuget.org/policies/Contact> / security@)
-  to request a hard delete (unlisting hides it but doesn't remove it), and note it
-  in `CHANGELOG.md` under **Security**.
+  then request a hard delete (unlisting hides it but doesn't remove it) —
+  [unlist it first](#unlist-a-package-version), file via the
+  [NuGet contact form](https://www.nuget.org/policies/Contact) and email
+  **support@nuget.org**, and for a platform-level compromise also report to the
+  Microsoft Security Response Center (**secure@microsoft.com** /
+  <https://msrc.microsoft.com/report>). Note it in `CHANGELOG.md` under **Security**.
 - Notify consumers via the advisory + release notes with the affected versions and
   the safe version to move to.
 

--- a/docs/DISASTER-RECOVERY.md
+++ b/docs/DISASTER-RECOVERY.md
@@ -1,0 +1,69 @@
+# Disaster Recovery — NuGet / GitHub account compromise
+
+Recovery actions after a credential compromise are time-critical and easy to
+fumble under stress. This runbook is the pre-written procedure. **Read it before
+you need it.** Work top-to-bottom; the ordering is deliberate (contain first,
+then eradicate, then communicate).
+
+> Scope: compromise of the NuGet.org account, the GitHub account/org, or the
+> machine/CI holding their credentials. Not for ordinary bugs or a bad release
+> (for a bad-but-not-malicious release, just [unlist](#unlist-a-package-version)
+> it and ship a fix).
+
+## 0. Assume breach — the accounts and keys involved
+
+| Asset | Where it lives | Blast radius if stolen |
+|---|---|---|
+| NuGet.org account | nuget.org login (protect with 2FA) | Publish/unlist any owned package |
+| NuGet API key / trusted-publishing | GitHub Actions secret / nuget.org trusted publisher policy | Publish new package versions |
+| GitHub account / PAT | github.com login, `~/.config/gh`, CI | Push code, edit workflows, releases, secrets |
+| Release signing cert (if adopted) | secure key store | Sign packages as us |
+
+## 1. Contain (minutes)
+
+1. **NuGet:** sign in → **Account → API Keys → Regenerate/Delete** every key.
+   If trusted publishing is used, remove the trusted-publisher policy for the repo.
+2. **GitHub:** **Settings → Password** (rotate) and **Developer settings → Personal
+   access tokens** (revoke all). **Settings → Sessions** → sign out everywhere.
+3. **Repo secrets:** **Settings → Secrets and variables → Actions** → rotate/delete
+   `NUGET_API_KEY` and anything else. Disable Actions if a workflow is actively
+   exfiltrating (`Settings → Actions → Disable`).
+4. If a **machine** was compromised, assume everything on it is exposed — rotate
+   from a known-clean device.
+
+## 2. Eradicate
+
+- Review recent **NuGet package versions** — [unlist](#unlist-a-package-version)
+  anything you didn't publish.
+- Review **GitHub**: recent commits, new/edited workflows, new collaborators,
+  new deploy keys, changed branch protection / rulesets, new releases. Revert
+  anything unexpected; remove rogue access.
+- Re-enable 2FA everywhere; require it for the org.
+
+## 3. Recover
+
+- Restore branch protection / rulesets from `repo-template` canonical.
+- Re-issue a clean `NUGET_API_KEY` (scoped to the `Wolfgang.*` package glob only,
+  "push new packages and versions") or re-establish trusted publishing.
+- Rebuild and re-release a known-good version from a clean checkout.
+
+## 4. Communicate
+
+- If a **malicious package version shipped**: open a security advisory on the repo,
+  contact **NuGet support** (<https://www.nuget.org/policies/Contact> / security@)
+  to request a hard delete (unlisting hides it but doesn't remove it), and note it
+  in `CHANGELOG.md` under **Security**.
+- Notify consumers via the advisory + release notes with the affected versions and
+  the safe version to move to.
+
+## Reference
+
+### Unlist a package version
+nuget.org → the package → **Manage → Listing** → uncheck the version → **Save**.
+Unlisting hides it from search/restore-by-default but existing lockfiles can still
+resolve it — for a malicious version, also request deletion via NuGet support.
+
+### Who has bypass / admin
+Repo admin(s) can admin-bypass branch protection (see
+[ADR-0001](adr/0001-vnext-protected-branching-model.md)). Keep the admin list
+minimal and 2FA-enforced.

--- a/docs/REPRODUCIBLE-BUILDS.md
+++ b/docs/REPRODUCIBLE-BUILDS.md
@@ -1,14 +1,14 @@
 # Reproducible builds — independent verification
 
-This package is built with reproducibility **inputs** enabled in
-`Directory.Build.props`:
+This package is built with reproducibility **inputs** enabled:
 
-- `<Deterministic>true</Deterministic>` — compiler output doesn't depend on wall
-  clock, machine paths, or ordering.
-- `<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>` (on CI) —
-  normalizes stored source paths.
-- SourceLink + `<EmbedUntrackedSources>` — the exact source is discoverable from
-  the symbols.
+- **Deterministic compilation** — `<Deterministic>` defaults to `true` for
+  SDK-style projects, so compiler output doesn't depend on the wall clock, machine
+  paths, or ordering.
+- `<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>` on CI (set in
+  `Directory.Build.props`) — normalizes stored source paths.
+- SourceLink + `<EmbedUntrackedSources>` (in `Directory.Build.props`) — the exact
+  source is discoverable from the symbols.
 
 That means a third party can rebuild the published package from source and confirm
 it matches — "trust, but verify". Here's how.
@@ -45,6 +45,21 @@ diff verify/mine.sha verify/theirs.sha && echo "✅ assemblies are byte-identica
 
 A clean `diff` proves the published binaries were built from this source with no
 injection in between.
+
+## If the hashes differ
+
+First rule out the benign causes below (a different SDK, or comparing the `.nupkg`
+zip instead of the assemblies). If the assemblies still differ after that, **treat
+it as a potential supply-chain discrepancy and report it**:
+
+- Open an issue at
+  <https://github.com/Chris-Wolfgang/Extensions-Logging-Data/issues> titled
+  "Reproducibility mismatch for v\<VERSION\>", including: the package version, your
+  **exact `dotnet --version`** and OS, and the two `sha256` lists (`verify/mine.sha`
+  and `verify/theirs.sha`) plus their `diff`.
+- If you believe the published package was tampered with (not just a toolchain
+  difference), also follow the reporting path in
+  [`SECURITY.md`](../SECURITY.md) / [`DISASTER-RECOVERY.md`](DISASTER-RECOVERY.md).
 
 ## Notes / caveats
 

--- a/docs/REPRODUCIBLE-BUILDS.md
+++ b/docs/REPRODUCIBLE-BUILDS.md
@@ -1,0 +1,59 @@
+# Reproducible builds — independent verification
+
+This package is built with reproducibility **inputs** enabled in
+`Directory.Build.props`:
+
+- `<Deterministic>true</Deterministic>` — compiler output doesn't depend on wall
+  clock, machine paths, or ordering.
+- `<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>` (on CI) —
+  normalizes stored source paths.
+- SourceLink + `<EmbedUntrackedSources>` — the exact source is discoverable from
+  the symbols.
+
+That means a third party can rebuild the published package from source and confirm
+it matches — "trust, but verify". Here's how.
+
+## Verify a published version yourself
+
+**Prerequisites:** the .NET SDK version the release was built with (see the release
+notes / `global.json` if present), and `git`.
+
+```bash
+# 1. Get the exact source for the version you want to verify.
+git clone https://github.com/Chris-Wolfgang/Extensions-Logging-Data.git
+cd Extensions-Logging-Data
+git checkout v<VERSION>          # e.g. v0.2.0 — the tag matches the package version
+
+# 2. Build the package the same way the release does.
+dotnet pack src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj \
+  -c Release -o ./verify
+
+# 3. Download the published package from NuGet.
+curl -sSL -o ./verify/published.nupkg \
+  "https://api.nuget.org/v3-flatcontainer/wolfgang.extensions.logging.data/<VERSION>/wolfgang.extensions.logging.data.<VERSION>.nupkg"
+
+# 4. Compare the compiled assembly inside each .nupkg. A .nupkg is a zip; the
+#    assembly is the reproducible artifact (the .nupkg envelope itself carries
+#    timestamps, so compare the DLLs, not the zip bytes).
+mkdir -p verify/mine verify/theirs
+unzip -oq verify/Wolfgang.Extensions.Logging.Data.<VERSION>.nupkg -d verify/mine
+unzip -oq verify/published.nupkg -d verify/theirs
+find verify/mine   -name '*.dll' -exec sha256sum {} \; | sed 's#verify/mine/##'   | sort > verify/mine.sha
+find verify/theirs -name '*.dll' -exec sha256sum {} \; | sed 's#verify/theirs/##' | sort > verify/theirs.sha
+diff verify/mine.sha verify/theirs.sha && echo "✅ assemblies are byte-identical"
+```
+
+A clean `diff` proves the published binaries were built from this source with no
+injection in between.
+
+## Notes / caveats
+
+- Compare the **assemblies** (`lib/**/*.dll`), not the `.nupkg` zip bytes — the
+  package envelope stores creation timestamps and isn't itself byte-reproducible.
+- Use the **same SDK major.minor**. A different Roslyn version can legitimately
+  produce different (but equally correct) IL.
+- The `net462` target may embed a framework-reference hash; if a specific TFM
+  differs, verify the others and file an issue noting the TFM.
+- This is the consumer-side counterpart to the repo's own build-reproducibility
+  check (which builds the same commit twice on CI and compares). If that check is
+  green and this local diff is clean, the chain from source to NuGet is verified.

--- a/docs/adr/0001-vnext-protected-branching-model.md
+++ b/docs/adr/0001-vnext-protected-branching-model.md
@@ -1,0 +1,47 @@
+# ADR-0001: vNext / protected-vNext release branching model
+
+- **Status:** Accepted
+- **Date:** 2026-07-13
+
+## Context
+
+The PR pipeline (`pr.yaml`) runs on `pull_request_target` targeting `main`, and a
+`Detect .NET Projects` guard **fails by design** whenever a PR touches a protected
+configuration file (`.github/workflows/*`, `Directory.Build.props`,
+`Directory.Build.targets`, `.editorconfig`, `BannedSymbols.txt`, `*.globalconfig`,
+`*.ruleset`). This makes protected-file PRs unmergeable without an admin bypass —
+intentional, so those files can't be weakened from within a PR.
+
+That is safe but awkward when a release bundles several changes, some of which
+touch protected files: every such PR would need its own admin-bypass, and the
+test stages never run (they `needs: detect-projects`, which fails).
+
+## Decision
+
+Accumulate a release on a per-cycle **`vNext`** integration branch, then land it
+through a short chain:
+
+```
+feature PRs ──▶ vNext ──▶ protected/vNext ──▶ main
+```
+
+- Feature PRs target **`vNext`**. Because `pr.yaml` only triggers on PRs whose base
+  is `main`, PRs into `vNext` don't run the guard at all — they merge normally.
+- `vNext → protected/vNext` is an integration PR (base isn't `main`, so no guard).
+- `protected/vNext → main` is the **single** admin-bypass hop that carries the
+  whole batch (protected files included) onto `main`.
+
+`vNext` and `protected/vNext` are **per-release-cycle**: created from `main` when a
+cycle starts, deleted after the batch lands. They are not long-lived branches.
+
+## Consequences
+
+- One admin-bypass per release instead of one per protected-file PR.
+- The trade-off: PRs targeting `vNext` get **no CI** (the stages are `main`-gated),
+  so real validation happens (a) locally before each push and (b) at the final
+  `protected/vNext → main` PR, where everything runs against `main`. Contributors
+  must verify locally — see `CONTRIBUTING.md`.
+- Do **not** treat `vNext` as permanent. After a release, leave it deleted; don't
+  auto-restore it. A new cycle recreates it from `main`.
+- A protected-file PR will always show `Detect .NET Projects: fail` and skipped
+  test stages — that is the guard working, not a broken pipeline.

--- a/docs/adr/0002-pinned-assemblyversion.md
+++ b/docs/adr/0002-pinned-assemblyversion.md
@@ -1,0 +1,34 @@
+# ADR-0002: Pin `AssemblyVersion` at `1.0.0.0`
+
+- **Status:** Accepted
+- **Date:** 2026-07-13 (documenting a decision first made for the v0.1.1 cycle)
+
+## Context
+
+The src project sets an explicit `<AssemblyVersion>1.0.0.0</AssemblyVersion>` while
+the package `<Version>` moves with every release (0.1.0, 0.1.1, 0.2.0, …). This
+looks stale and is a tempting "cleanup" target — surely the assembly version
+should track the package version?
+
+The package ships a `net462` target. On .NET Framework, assembly binding is
+**version-exact**: if `AssemblyVersion` changes on every minor/patch release, every
+consumer must recompile or add a binding redirect just to pick up a bug-fix. A
+regression that let the SDK derive `AssemblyVersion` from `<Version>` (dropping the
+pin) reached a release elsewhere in the fleet and broke .NET Framework consumers —
+the post-mortem is why this is now an explicit, documented decision.
+
+## Decision
+
+Keep `<AssemblyVersion>1.0.0.0</AssemblyVersion>` pinned. Carry the real release
+version in `<FileVersion>` (regex-stripped from `<Version>`) and
+`<InformationalVersion>` (auto-derived), which do **not** participate in binding.
+Bump `AssemblyVersion` only on a deliberate **breaking** API change.
+
+## Consequences
+
+- .NET Framework consumers get patch/minor updates without recompiles or binding
+  redirects.
+- `AssemblyVersion` no longer identifies the release — use `FileVersion` /
+  `InformationalVersion` / the NuGet package version for that.
+- **Do not** remove the pin or let it be SDK-derived, even though it looks stale.
+  If tooling or a template sync tries to drop it, restore it.

--- a/docs/adr/0003-anonymous-object-overload-not-aot-safe.md
+++ b/docs/adr/0003-anonymous-object-overload-not-aot-safe.md
@@ -1,0 +1,43 @@
+# ADR-0003: Anonymous-object `LogCommandText` overloads are not trim/AOT-safe
+
+- **Status:** Accepted
+- **Date:** 2026-07-13
+
+## Context
+
+`LogCommandText` has two parameter-supplying styles: an explicit
+`IReadOnlyDictionary<string, object?>` and a Dapper-style anonymous object
+(`new { id = 1 }`). The anonymous-object path reflects over the runtime type's
+public properties (`Type.GetProperties` + `PropertyInfo.GetValue`) to build the
+name/value map.
+
+Under IL trimming / Native AOT, the trimmer cannot statically see which properties
+a reflected-over type has, so it may remove them — turning the overload into a
+silent no-op (empty parameters). We evaluated annotating the parameter with
+`[DynamicallyAccessedMembers(PublicProperties)]` to make the trimmer preserve them,
+but that attribute is **only valid on `Type` / `string` parameters** — applying it
+to an `object` parameter is `IL2098`. There is no annotation that makes reflecting
+over an arbitrary `object`'s properties trim-safe.
+
+## Decision
+
+Mark the four anonymous-object `LogCommandText(..., object parameters, ...)`
+overloads (and the internal `ToDictionary(object)` / `BuildPropertyReader` helpers)
+`[RequiresUnreferencedCode]`. Consumers building trimmed / AOT apps get an `IL2026`
+warning directing them to the dictionary overload, which is trim/AOT-safe.
+`RequiresUnreferencedCodeAttribute` is polyfilled for the pre-net5 target
+frameworks (net462, netstandard2.0/2.1).
+
+The trim/AOT-safe surface (`LogDbConnection`, `LogDbCommand`, the dictionary
+`LogCommandText`) is verified by a `PublishAot` smoke consumer in CI.
+
+## Consequences
+
+- The library's AOT story is honest and enforced: the safe surface is verified;
+  the unsafe overload is flagged at the call site rather than failing silently.
+- Non-trimmed consumers are unaffected — `[RequiresUnreferencedCode]` produces no
+  warning outside trim/AOT analysis.
+- **Do not** "fix" the `IL2026` by adding `[DynamicallyAccessedMembers]` to the
+  `object` parameter — it is invalid there (`IL2098`). If a genuinely trim-safe
+  design is wanted, it requires a source-generator or an explicit dictionary API,
+  not an annotation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,33 @@
+# Architecture Decision Records
+
+This folder captures **non-obvious design decisions** — the ones whose rationale
+is easy to lose six months after the PR that introduced them. Each ADR records
+the *context*, the *decision*, and the *consequences* so a future maintainer (or
+you-in-six-months) doesn't re-derive the same trade-off poorly, or silently undo
+a deliberate choice.
+
+## When to write one
+
+Write an ADR when a decision is **not self-evident from the code** and would be
+tempting to "clean up" without knowing why it's there. Examples: a deliberate
+API-shape choice, a pinned version that looks stale, a banned API, a security
+posture, a branching/release convention. Routine, obvious choices don't need one.
+
+## How to add one
+
+1. Copy [`TEMPLATE.md`](TEMPLATE.md) to `NNNN-short-kebab-title.md`, using the
+   next free zero-padded number.
+2. Fill in Context / Decision / Consequences. Keep it short — a screenful.
+3. Set the status (`Proposed` → `Accepted`, later maybe `Superseded by ADR-XXXX`).
+4. Add a row to the index below.
+
+ADRs are **immutable once accepted** — don't rewrite history. If a decision
+changes, write a new ADR that supersedes the old one and update both statuses.
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](0001-vnext-protected-branching-model.md) | vNext / protected-vNext release branching model | Accepted |
+| [0002](0002-pinned-assemblyversion.md) | Pin `AssemblyVersion` at `1.0.0.0` | Accepted |
+| [0003](0003-anonymous-object-overload-not-aot-safe.md) | Anonymous-object `LogCommandText` overloads are not trim/AOT-safe | Accepted |

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,20 @@
+# ADR-NNNN: <short decision title>
+
+- **Status:** Proposed | Accepted | Superseded by ADR-XXXX
+- **Date:** YYYY-MM-DD
+
+## Context
+
+What is the situation, constraint, or problem that forces a decision? What
+options were on the table? Include the forces (performance, compatibility,
+security, maintainability) that pull in different directions.
+
+## Decision
+
+The choice that was made, stated plainly. "We will …".
+
+## Consequences
+
+What becomes easier and what becomes harder as a result. Include the accepted
+downsides — an ADR that lists only upsides is hiding something. Note anything a
+future maintainer must NOT do (e.g. "do not remove X — it looks stale but …").

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,24 @@
+# Migration guides
+
+When a **major** version ships with breaking changes (e.g. `0.x → 1.0`, or
+`1.x → 2.0`), consumers need a written upgrade path: what was renamed / removed /
+behaviourally changed, the replacement, and before/after code.
+
+No major version with breaking changes has shipped yet, so there are no migration
+guides here — only the **convention**, established now so it's ready when needed:
+
+## Convention
+
+- One file per major transition: `v{from}-to-v{to}.md` (e.g. `v1-to-v2.md`).
+- Start from [`TEMPLATE-major-version-migration.md`](TEMPLATE-major-version-migration.md).
+- Write it **as part of the PR that introduces the break**, not after release —
+  the author has the context then.
+- Link it from the `CHANGELOG.md` entry for that release and from the release notes.
+- SemVer reminder: breaking changes are only allowed in a **major** bump (and, for
+  `0.x`, a minor bump per SemVer's 0.x clause). If you're writing one of these for
+  a patch, something is wrong.
+
+## Index
+
+_None yet — the library is pre-1.0. The first entry lands with the first breaking
+major release._

--- a/docs/migrations/TEMPLATE-major-version-migration.md
+++ b/docs/migrations/TEMPLATE-major-version-migration.md
@@ -1,0 +1,41 @@
+# Migrating from v{FROM} to v{TO}
+
+> One-paragraph summary: who is affected, roughly how much work, and whether the
+> upgrade can be done incrementally.
+
+## At a glance
+
+| Change | Kind | Action |
+|---|---|---|
+| `OldApi(...)` | Renamed → `NewApi(...)` | Mechanical rename |
+| `SomeType.OldProp` | Removed | Use `NewProp` |
+| `Method(...)` default behaviour | Changed | Review call sites; pass X explicitly to keep old behaviour |
+
+## Breaking changes in detail
+
+### 1. `<what changed>`
+
+**Why:** <the reason — link the ADR or PR>.
+
+**Before:**
+
+```csharp
+// old usage
+```
+
+**After:**
+
+```csharp
+// new usage
+```
+
+## Non-breaking additions worth adopting
+
+- <new API> — <what it gives you>.
+
+## Upgrade checklist
+
+- [ ] Bump the package reference to `{TO}`.
+- [ ] Apply the renames/replacements above (the compiler flags most of them).
+- [ ] Re-run tests; review any changed-behaviour call sites.
+- [ ] Remove any workarounds that the new version makes unnecessary.


### PR DESCRIPTION
Resolves four thorough-review docs issues in one PR (docs-only, no protected files → merges to `vNext` cleanly).

| Issue | Deliverable |
|---|---|
| **#101** ADRs | `docs/adr/` — index + template + 3 real records (vNext branching, pinned AssemblyVersion, anonymous-object-not-AOT-safe) |
| **#102** DR runbook | `docs/DISASTER-RECOVERY.md` — contain → eradicate → recover → communicate, with key inventory + unlist/NuGet-support steps |
| **#100** migration guides | `docs/migrations/` — README (convention) + major-version template. AC only asked to establish the convention now (still pre-1.0) |
| **#106** reproducible (consumer-side) | `docs/REPRODUCIBLE-BUILDS.md` — how a third party rebuilds a published version from the tag and diffs assemblies vs NuGet |

All linked from the README Documentation section. The ADRs capture decisions made across recent sessions so they don't get re-derived or silently undone.

`Closes #100 #101 #102 #106`.