### PR TITLE
ci: verify build reproducibility (#97)

### DIFF
--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -1,0 +1,89 @@
+# ============================================================================
+# Reproducible-build verification. Directory.Build.props sets the reproducibility
+# INPUTS (Deterministic, ContinuousIntegrationBuild, SourceLink); this workflow
+# VERIFIES the output: it builds the same commit twice in independent jobs and
+# fails if the compiled Wolfgang.* assemblies are not byte-identical. Consumers
+# can reproduce the same check from source — see docs/REPRODUCIBLE-BUILDS.md.
+# ============================================================================
+name: Reproducible Build
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: "Build (attempt ${{ matrix.attempt }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        attempt: [1, 2]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build (Release, deterministic)
+        run: |
+          # ContinuousIntegrationBuild normalizes stored source paths so two CI
+          # runs of the same commit produce identical output.
+          dotnet build -c Release -p:ContinuousIntegrationBuild=true
+
+      - name: Hash the built Wolfgang.* assemblies
+        run: |
+          find src -path '*/bin/Release/*' -name 'Wolfgang.Extensions.Logging.Data*.dll' -print0 \
+            | sort -z \
+            | while IFS= read -r -d '' dll; do
+                # Key by <tfm>/<file> so the two attempts line up regardless of
+                # absolute path ordering.
+                key=$(echo "$dll" | sed -E 's#.*/bin/Release/##')
+                echo "$(sha256sum "$dll" | cut -d' ' -f1)  $key"
+              done | sort > "hashes.txt"
+          echo "=== attempt ${{ matrix.attempt }} hashes ==="
+          cat hashes.txt
+
+      - name: Upload hashes
+        uses: actions/upload-artifact@v4
+        with:
+          name: hashes-${{ matrix.attempt }}
+          path: hashes.txt
+          retention-days: 3
+
+  compare:
+    name: "Compare attempts"
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download attempt 1
+        uses: actions/download-artifact@v4
+        with:
+          name: hashes-1
+          path: a1
+
+      - name: Download attempt 2
+        uses: actions/download-artifact@v4
+        with:
+          name: hashes-2
+          path: a2
+
+      - name: Assert byte-identical
+        run: |
+          if diff -u a1/hashes.txt a2/hashes.txt; then
+            echo "✅ Build is reproducible — both attempts produced byte-identical assemblies."
+          else
+            echo "::error::Build is NOT reproducible — assembly hashes differ between two builds of the same commit. See the diff above."
+            exit 1
+          fi

--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -1,9 +1,16 @@
 # ============================================================================
-# Reproducible-build verification. Directory.Build.props sets the reproducibility
-# INPUTS (Deterministic, ContinuousIntegrationBuild, SourceLink); this workflow
-# VERIFIES the output: it builds the same commit twice in independent jobs and
-# fails if the compiled Wolfgang.* assemblies are not byte-identical. Consumers
-# can reproduce the same check from source — see docs/REPRODUCIBLE-BUILDS.md.
+# Reproducible-build verification. Determinism is the SDK default for SDK-style
+# projects, and Directory.Build.props adds the remaining reproducibility inputs
+# (ContinuousIntegrationBuild path-normalization on CI, SourceLink,
+# EmbedUntrackedSources). This workflow VERIFIES the output: it builds the same
+# commit twice PER OS (ubuntu + windows) and fails if a given OS's two builds are
+# not byte-identical. Consumers reproduce the same check from source — see
+# docs/REPRODUCIBLE-BUILDS.md (added alongside this workflow).
+#
+# Note: the gate is per-OS determinism, not cross-OS byte-identity. Cross-OS
+# byte-identical assemblies (esp. PDBs and the net462 target) are not reliably
+# achievable, which is why the acceptance criteria hedge "different OS where
+# possible" — building on both OSes proves each is internally deterministic.
 # ============================================================================
 name: Reproducible Build
 
@@ -19,11 +26,12 @@ permissions:
 
 jobs:
   build:
-    name: "Build (attempt ${{ matrix.attempt }})"
-    runs-on: ubuntu-latest
+    name: "Build ${{ matrix.os }} (attempt ${{ matrix.attempt }})"
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         attempt: [1, 2]
     steps:
       - name: Checkout code
@@ -37,53 +45,81 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Build (Release, deterministic)
+        shell: bash
         run: |
+          # Resolve the solution explicitly (no bare `dotnet build`) so a repo with
+          # more than one solution/project at the root can't fail on CLI
+          # disambiguation. `./`-prefixed glob is dash-safe; guard the no-match case.
+          SLN=""
+          for candidate in ./*.slnx ./*.sln; do
+            if [ -e "$candidate" ]; then SLN="$candidate"; break; fi
+          done
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln at repo root."
+            exit 1
+          fi
+          echo "Building: $SLN"
           # ContinuousIntegrationBuild normalizes stored source paths so two CI
-          # runs of the same commit produce identical output.
-          dotnet build -c Release -p:ContinuousIntegrationBuild=true
+          # runs of the same commit on the same OS produce identical output.
+          dotnet build "$SLN" -c Release -p:ContinuousIntegrationBuild=true
 
-      - name: Hash the built Wolfgang.* assemblies
+      - name: Hash the built Wolfgang.* artifacts
+        shell: bash
         run: |
-          find src -path '*/bin/Release/*' -name 'Wolfgang.Extensions.Logging.Data*.dll' -print0 \
-            | sort -z \
-            | while IFS= read -r -d '' dll; do
-                # Key by <tfm>/<file> so the two attempts line up regardless of
-                # absolute path ordering.
-                key=$(echo "$dll" | sed -E 's#.*/bin/Release/##')
-                echo "$(sha256sum "$dll" | cut -d' ' -f1)  $key"
-              done | sort > "hashes.txt"
-          echo "=== attempt ${{ matrix.attempt }} hashes ==="
+          # Hash both the assemblies and their symbols (.dll + .pdb) so a symbol
+          # regression is caught too. Key by <tfm>/<file> so the two attempts line
+          # up regardless of path ordering.
+          : > hashes.txt
+          while IFS= read -r -d '' f; do
+            key=$(echo "$f" | sed -E 's#.*/bin/Release/##')
+            echo "$(sha256sum "$f" | cut -d' ' -f1)  $key" >> hashes.txt
+          done < <(find src -path '*/bin/Release/*' \( -name 'Wolfgang.Extensions.Logging.Data*.dll' -o -name 'Wolfgang.Extensions.Logging.Data*.pdb' \) -print0)
+          sort -o hashes.txt hashes.txt
+
+          # Fail loudly if nothing was hashed — otherwise an empty file would make
+          # the compare job pass vacuously (e.g. if outputs move or a project is renamed).
+          count=$(wc -l < hashes.txt)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No Wolfgang.* build artifacts were found to hash — the find pattern or output layout changed."
+            exit 1
+          fi
+          echo "=== ${{ matrix.os }} attempt ${{ matrix.attempt }}: $count artifacts ==="
           cat hashes.txt
 
       - name: Upload hashes
         uses: actions/upload-artifact@v4
         with:
-          name: hashes-${{ matrix.attempt }}
+          name: hashes-${{ matrix.os }}-${{ matrix.attempt }}
           path: hashes.txt
           retention-days: 3
 
   compare:
-    name: "Compare attempts"
+    name: "Compare (per-OS determinism)"
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Download attempt 1
+      - name: Download all hashes
         uses: actions/download-artifact@v4
         with:
-          name: hashes-1
-          path: a1
+          path: hashes
 
-      - name: Download attempt 2
-        uses: actions/download-artifact@v4
-        with:
-          name: hashes-2
-          path: a2
-
-      - name: Assert byte-identical
+      - name: Assert each OS is deterministic
+        shell: bash
         run: |
-          if diff -u a1/hashes.txt a2/hashes.txt; then
-            echo "✅ Build is reproducible — both attempts produced byte-identical assemblies."
-          else
-            echo "::error::Build is NOT reproducible — assembly hashes differ between two builds of the same commit. See the diff above."
-            exit 1
-          fi
+          rc=0
+          for os in ubuntu-latest windows-latest; do
+            a="hashes/hashes-$os-1/hashes.txt"
+            b="hashes/hashes-$os-2/hashes.txt"
+            if [ ! -s "$a" ] || [ ! -s "$b" ]; then
+              echo "::error::Missing or empty hashes for $os."
+              rc=1
+              continue
+            fi
+            if diff -u "$a" "$b"; then
+              echo "✅ $os: two builds of the same commit are byte-identical."
+            else
+              echo "::error::$os build is NOT reproducible — assembly/symbol hashes differ between two builds of the same commit (diff above)."
+              rc=1
+            fi
+          done
+          exit "$rc"


### PR DESCRIPTION
Closes #97.

## What
`.github/workflows/reproducible-build.yaml` — builds the same commit **twice** in independent jobs and fails if the compiled `Wolfgang.*` assemblies aren't **byte-identical**. Directory.Build.props already provides the reproducibility *inputs* (`Deterministic`, `ContinuousIntegrationBuild`, SourceLink); this *verifies* the output.

Runs on `pull_request`/`push` to `main` + `workflow_dispatch`. Pairs with `docs/REPRODUCIBLE-BUILDS.md` (#106, consumer-side verification).

## Verified locally
Two clean `-c Release -p:ContinuousIntegrationBuild=true` builds of the same commit → **identical sha256 across every TFM** (net462/net48/netstandard2.0/2.1/net10.0). Workflow passes YAML + actionlint + zizmor.

## ⚠️ Merge note
New workflow file (protected) → lands via the `vNext → main` admin-bypass hop; it can't run on this vNext-targeted PR (the trigger is `main`-gated).