### PR TITLE
ci(release): SLSA build-provenance attestation (#90 partial)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -585,7 +585,12 @@ jobs:
         if: steps.check-packages.outputs.has-packages == 'true'
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: 'nuget-packages/*.nupkg'
+          # Attest every shipped artifact: the packages, their symbol packages,
+          # and the CycloneDX SBOMs generated above.
+          subject-path: |
+            nuget-packages/*.nupkg
+            nuget-packages/*.snupkg
+            nuget-packages/*.bom.json
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -350,6 +350,10 @@ jobs:
     name: Pack & Validate NuGet
     needs: validate-release
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write        # SLSA build-provenance attestation (OIDC)
+      attestations: write    # SLSA build-provenance attestation
     outputs:
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
@@ -571,6 +575,17 @@ jobs:
             }
           }
 
+
+      # SLSA build-provenance attestation: cryptographically links each .nupkg to
+      # this repo + commit + workflow run, so a consumer can verify (via
+      # `gh attestation verify <nupkg> --repo Chris-Wolfgang/Extensions-Logging-Data`)
+      # that the package was built here and not injected downstream. Complements the
+      # SBOM above. (Author signing with a certificate is a separate follow-up.)
+      - name: Attest build provenance (SLSA)
+        if: steps.check-packages.outputs.has-packages == 'true'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'nuget-packages/*.nupkg'
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Refs #90 (supply-chain hardening).

## What
Adds `actions/attest-build-provenance@v2` to the release pack job — it cryptographically attests every `.nupkg` (repo + commit + workflow run) so a consumer can verify provenance:

```
gh attestation verify <package.nupkg> --repo Chris-Wolfgang/Extensions-Logging-Data
```

The job gains `id-token: write` + `attestations: write`. Complements the existing CycloneDX **SBOM** step.

## #90 status after this
- ✅ **SBOM** (CycloneDX) — already in release.yaml
- ✅ **SLSA provenance attestation** — this PR
- ⛔ **Author package signing** — needs a signing **certificate** (NuGet trusted-signer or Sigstore); that's a maintainer action, so #90 stays open for it.

Validated: YAML + actionlint + zizmor clean. The attestation itself runs only at release (needs OIDC), so it can't be exercised on a PR.

## ⚠️ Merge note
Touches `release.yaml` (protected) → lands via the `vNext → main` admin-bypass hop.