### PR TITLE
Release batch → main: #94 AOT + maintenance docs/CI (protected/vNext)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -353,6 +353,67 @@ jobs:
           echo "✅ No error-severity InspectCode findings."
 
   # ============================================================================
+  # AOT SMOKE: publish a Native-AOT + trimmed consumer of the library and run it.
+  # The trim/AOT analyzers (TreatWarningsAsErrors) fail the build on any regression
+  # to the AOT-safe surface; running the native binary catches runtime breaks
+  # (MissingMethod / NotSupported / silent no-op). Parallel to the test stages.
+  # ============================================================================
+  aot-smoke:
+    name: "Native AOT smoke"
+    runs-on: ubuntu-latest
+    needs: detect-projects
+    # Same-repo PRs only — builds PR code under pull_request_target (see the
+    # inspectcode job for the rationale).
+    if: >-
+      github.repository != 'Chris-Wolfgang/repo-template'
+      && needs.detect-projects.outputs.has-projects == 'true'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install Native AOT prerequisites
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Find the AOT smoke project
+        id: smoke
+        run: |
+          PROJ=$(find . -name '*.AotSmoke.csproj' | head -n1)
+          if [ -z "$PROJ" ]; then
+            echo "No *.AotSmoke.csproj found — skipping."
+            echo "found=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Smoke project: $PROJ"
+            echo "found=$PROJ" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish Native AOT (trim + AOT analyzers gate the build)
+        if: steps.smoke.outputs.found != ''
+        run: dotnet publish "${{ steps.smoke.outputs.found }}" -c Release -r linux-x64
+
+      - name: Run the published native binary
+        if: steps.smoke.outputs.found != ''
+        run: |
+          BIN=$(find "$(dirname "${{ steps.smoke.outputs.found }}")/bin" -type f -name '*.AotSmoke' -path '*publish*' | head -n1)
+          if [ -z "$BIN" ]; then
+            echo "::error::Native AOT binary not produced."
+            exit 1
+          fi
+          echo "Running: $BIN"
+          "$BIN"
+
+  # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
   test-linux-core:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -585,7 +585,12 @@ jobs:
         if: steps.check-packages.outputs.has-packages == 'true'
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: 'nuget-packages/*.nupkg'
+          # Attest every shipped artifact: the packages, their symbol packages,
+          # and the CycloneDX SBOMs generated above.
+          subject-path: |
+            nuget-packages/*.nupkg
+            nuget-packages/*.snupkg
+            nuget-packages/*.bom.json
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -350,6 +350,10 @@ jobs:
     name: Pack & Validate NuGet
     needs: validate-release
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write        # SLSA build-provenance attestation (OIDC)
+      attestations: write    # SLSA build-provenance attestation
     outputs:
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
@@ -571,6 +575,17 @@ jobs:
             }
           }
 
+
+      # SLSA build-provenance attestation: cryptographically links each .nupkg to
+      # this repo + commit + workflow run, so a consumer can verify (via
+      # `gh attestation verify <nupkg> --repo Chris-Wolfgang/Extensions-Logging-Data`)
+      # that the package was built here and not injected downstream. Complements the
+      # SBOM above. (Author signing with a certificate is a separate follow-up.)
+      - name: Attest build provenance (SLSA)
+        if: steps.check-packages.outputs.has-packages == 'true'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'nuget-packages/*.nupkg'
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v7

--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -1,0 +1,89 @@
+# ============================================================================
+# Reproducible-build verification. Directory.Build.props sets the reproducibility
+# INPUTS (Deterministic, ContinuousIntegrationBuild, SourceLink); this workflow
+# VERIFIES the output: it builds the same commit twice in independent jobs and
+# fails if the compiled Wolfgang.* assemblies are not byte-identical. Consumers
+# can reproduce the same check from source — see docs/REPRODUCIBLE-BUILDS.md.
+# ============================================================================
+name: Reproducible Build
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: "Build (attempt ${{ matrix.attempt }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        attempt: [1, 2]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build (Release, deterministic)
+        run: |
+          # ContinuousIntegrationBuild normalizes stored source paths so two CI
+          # runs of the same commit produce identical output.
+          dotnet build -c Release -p:ContinuousIntegrationBuild=true
+
+      - name: Hash the built Wolfgang.* assemblies
+        run: |
+          find src -path '*/bin/Release/*' -name 'Wolfgang.Extensions.Logging.Data*.dll' -print0 \
+            | sort -z \
+            | while IFS= read -r -d '' dll; do
+                # Key by <tfm>/<file> so the two attempts line up regardless of
+                # absolute path ordering.
+                key=$(echo "$dll" | sed -E 's#.*/bin/Release/##')
+                echo "$(sha256sum "$dll" | cut -d' ' -f1)  $key"
+              done | sort > "hashes.txt"
+          echo "=== attempt ${{ matrix.attempt }} hashes ==="
+          cat hashes.txt
+
+      - name: Upload hashes
+        uses: actions/upload-artifact@v4
+        with:
+          name: hashes-${{ matrix.attempt }}
+          path: hashes.txt
+          retention-days: 3
+
+  compare:
+    name: "Compare attempts"
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download attempt 1
+        uses: actions/download-artifact@v4
+        with:
+          name: hashes-1
+          path: a1
+
+      - name: Download attempt 2
+        uses: actions/download-artifact@v4
+        with:
+          name: hashes-2
+          path: a2
+
+      - name: Assert byte-identical
+        run: |
+          if diff -u a1/hashes.txt a2/hashes.txt; then
+            echo "✅ Build is reproducible — both attempts produced byte-identical assemblies."
+          else
+            echo "::error::Build is NOT reproducible — assembly hashes differ between two builds of the same commit. See the diff above."
+            exit 1
+          fi

--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -1,9 +1,16 @@
 # ============================================================================
-# Reproducible-build verification. Directory.Build.props sets the reproducibility
-# INPUTS (Deterministic, ContinuousIntegrationBuild, SourceLink); this workflow
-# VERIFIES the output: it builds the same commit twice in independent jobs and
-# fails if the compiled Wolfgang.* assemblies are not byte-identical. Consumers
-# can reproduce the same check from source — see docs/REPRODUCIBLE-BUILDS.md.
+# Reproducible-build verification. Determinism is the SDK default for SDK-style
+# projects, and Directory.Build.props adds the remaining reproducibility inputs
+# (ContinuousIntegrationBuild path-normalization on CI, SourceLink,
+# EmbedUntrackedSources). This workflow VERIFIES the output: it builds the same
+# commit twice PER OS (ubuntu + windows) and fails if a given OS's two builds are
+# not byte-identical. Consumers reproduce the same check from source — see
+# docs/REPRODUCIBLE-BUILDS.md (added alongside this workflow).
+#
+# Note: the gate is per-OS determinism, not cross-OS byte-identity. Cross-OS
+# byte-identical assemblies (esp. PDBs and the net462 target) are not reliably
+# achievable, which is why the acceptance criteria hedge "different OS where
+# possible" — building on both OSes proves each is internally deterministic.
 # ============================================================================
 name: Reproducible Build
 
@@ -19,11 +26,12 @@ permissions:
 
 jobs:
   build:
-    name: "Build (attempt ${{ matrix.attempt }})"
-    runs-on: ubuntu-latest
+    name: "Build ${{ matrix.os }} (attempt ${{ matrix.attempt }})"
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         attempt: [1, 2]
     steps:
       - name: Checkout code
@@ -37,53 +45,81 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Build (Release, deterministic)
+        shell: bash
         run: |
+          # Resolve the solution explicitly (no bare `dotnet build`) so a repo with
+          # more than one solution/project at the root can't fail on CLI
+          # disambiguation. `./`-prefixed glob is dash-safe; guard the no-match case.
+          SLN=""
+          for candidate in ./*.slnx ./*.sln; do
+            if [ -e "$candidate" ]; then SLN="$candidate"; break; fi
+          done
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln at repo root."
+            exit 1
+          fi
+          echo "Building: $SLN"
           # ContinuousIntegrationBuild normalizes stored source paths so two CI
-          # runs of the same commit produce identical output.
-          dotnet build -c Release -p:ContinuousIntegrationBuild=true
+          # runs of the same commit on the same OS produce identical output.
+          dotnet build "$SLN" -c Release -p:ContinuousIntegrationBuild=true
 
-      - name: Hash the built Wolfgang.* assemblies
+      - name: Hash the built Wolfgang.* artifacts
+        shell: bash
         run: |
-          find src -path '*/bin/Release/*' -name 'Wolfgang.Extensions.Logging.Data*.dll' -print0 \
-            | sort -z \
-            | while IFS= read -r -d '' dll; do
-                # Key by <tfm>/<file> so the two attempts line up regardless of
-                # absolute path ordering.
-                key=$(echo "$dll" | sed -E 's#.*/bin/Release/##')
-                echo "$(sha256sum "$dll" | cut -d' ' -f1)  $key"
-              done | sort > "hashes.txt"
-          echo "=== attempt ${{ matrix.attempt }} hashes ==="
+          # Hash both the assemblies and their symbols (.dll + .pdb) so a symbol
+          # regression is caught too. Key by <tfm>/<file> so the two attempts line
+          # up regardless of path ordering.
+          : > hashes.txt
+          while IFS= read -r -d '' f; do
+            key=$(echo "$f" | sed -E 's#.*/bin/Release/##')
+            echo "$(sha256sum "$f" | cut -d' ' -f1)  $key" >> hashes.txt
+          done < <(find src -path '*/bin/Release/*' \( -name 'Wolfgang.Extensions.Logging.Data*.dll' -o -name 'Wolfgang.Extensions.Logging.Data*.pdb' \) -print0)
+          sort -o hashes.txt hashes.txt
+
+          # Fail loudly if nothing was hashed — otherwise an empty file would make
+          # the compare job pass vacuously (e.g. if outputs move or a project is renamed).
+          count=$(wc -l < hashes.txt)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No Wolfgang.* build artifacts were found to hash — the find pattern or output layout changed."
+            exit 1
+          fi
+          echo "=== ${{ matrix.os }} attempt ${{ matrix.attempt }}: $count artifacts ==="
           cat hashes.txt
 
       - name: Upload hashes
         uses: actions/upload-artifact@v4
         with:
-          name: hashes-${{ matrix.attempt }}
+          name: hashes-${{ matrix.os }}-${{ matrix.attempt }}
           path: hashes.txt
           retention-days: 3
 
   compare:
-    name: "Compare attempts"
+    name: "Compare (per-OS determinism)"
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Download attempt 1
+      - name: Download all hashes
         uses: actions/download-artifact@v4
         with:
-          name: hashes-1
-          path: a1
+          path: hashes
 
-      - name: Download attempt 2
-        uses: actions/download-artifact@v4
-        with:
-          name: hashes-2
-          path: a2
-
-      - name: Assert byte-identical
+      - name: Assert each OS is deterministic
+        shell: bash
         run: |
-          if diff -u a1/hashes.txt a2/hashes.txt; then
-            echo "✅ Build is reproducible — both attempts produced byte-identical assemblies."
-          else
-            echo "::error::Build is NOT reproducible — assembly hashes differ between two builds of the same commit. See the diff above."
-            exit 1
-          fi
+          rc=0
+          for os in ubuntu-latest windows-latest; do
+            a="hashes/hashes-$os-1/hashes.txt"
+            b="hashes/hashes-$os-2/hashes.txt"
+            if [ ! -s "$a" ] || [ ! -s "$b" ]; then
+              echo "::error::Missing or empty hashes for $os."
+              rc=1
+              continue
+            fi
+            if diff -u "$a" "$b"; then
+              echo "✅ $os: two builds of the same commit are byte-identical."
+            else
+              echo "::error::$os build is NOT reproducible — assembly/symbol hashes differ between two builds of the same commit (diff above)."
+              rc=1
+            fi
+          done
+          exit "$rc"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.3.0] - 2026-07-14
+
+`Wolfgang.Extensions.Logging.Data` only. The `EntityFramework6` companion package
+is unchanged and stays at 0.2.0.
+
+### Added
+
 - **Trim / Native AOT compatibility.** The `LogDbConnection`, `LogDbCommand`,
   and dictionary-based `LogCommandText` surface is verified trim- and AOT-safe by
   a `PublishAot` + `PublishTrimmed` smoke consumer run in CI. (#94)
@@ -21,14 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Native AOT apps get an `IL2026` warning; use the
   `IReadOnlyDictionary<string, object?>` overload instead. No change for
   non-trimmed consumers. (#94)
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
 
 ## [0.2.0] - 2026-07-06
 
@@ -121,7 +130,8 @@ Initial release.
 - Multi-targeting: `net462`, `netstandard2.0`, `netstandard2.1`,
   `net10.0`.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Trim / Native AOT compatibility.** The `LogDbConnection`, `LogDbCommand`,
+  and dictionary-based `LogCommandText` surface is verified trim- and AOT-safe by
+  a `PublishAot` + `PublishTrimmed` smoke consumer run in CI. (#94)
+
 ### Changed
+
+- The **anonymous-object `LogCommandText(..., object parameters, ...)` overloads
+  are now marked `[RequiresUnreferencedCode]`** — they reflect over the runtime
+  type's properties, which the trimmer cannot preserve. Callers in trimmed /
+  Native AOT apps get an `IL2026` warning; use the
+  `IReadOnlyDictionary<string, object?>` overload instead. No change for
+  non-trimmed consumers. (#94)
 
 ### Deprecated
 

--- a/Extensions-Logging-Data.slnx
+++ b/Extensions-Logging-Data.slnx
@@ -54,6 +54,7 @@
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj" />
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit/Wolfgang.Extensions.Logging.Data.EntityFramework6.Tests.Unit.csproj" />
     <Project Path="tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/Wolfgang.Extensions.Logging.Data.Tests.Docs.csproj" />
+    <Project Path="tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Wolfgang.Extensions.Logging.Data.AotSmoke.csproj" />
   </Folder>
 </Solution>
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ logger.LogDbConnection(connection, LogLevel.Debug);
 
 `DbCommand` logging is also available via `ILogger.LogCommandText(...)` (command text + parameter snapshot with opt-in redaction) and `ILogger.LogDbCommand(DbCommand, ...)` (logs a live command directly). The library is intentionally narrow and grows one type at a time as needed.
 
+> **Trimming / Native AOT:** `LogDbConnection`, `LogDbCommand`, and the `IReadOnlyDictionary<string, object?>` overloads of `LogCommandText` are trim- and AOT-safe (verified by a `PublishAot` smoke in CI). The **anonymous-object** `LogCommandText(..., object parameters, ...)` overloads reflect over the parameter's runtime properties and are marked `[RequiresUnreferencedCode]` — in trimmed/AOT apps use the dictionary overload instead.
+
 ---
 
 ## 🪵 Entity Framework 6 companion

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 - **API Documentation:** https://Chris-Wolfgang.github.io/Extensions-Logging-Data/
 - **CHANGELOG:** [CHANGELOG.md](CHANGELOG.md)
 - **Contributing Guide:** [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Architecture Decision Records:** [docs/adr/](docs/adr/README.md)
+- **Reproducible builds (independent verification):** [docs/REPRODUCIBLE-BUILDS.md](docs/REPRODUCIBLE-BUILDS.md)
+- **Migration guides:** [docs/migrations/](docs/migrations/README.md)
+- **Disaster recovery runbook:** [docs/DISASTER-RECOVERY.md](docs/DISASTER-RECOVERY.md)
 - **DocFX Version Picker Troubleshooting:** [docs/DOCFX-VERSION-PICKER.md](docs/DOCFX-VERSION-PICKER.md)
 
 ---

--- a/docs/DISASTER-RECOVERY.md
+++ b/docs/DISASTER-RECOVERY.md
@@ -50,9 +50,12 @@ then eradicate, then communicate).
 ## 4. Communicate
 
 - If a **malicious package version shipped**: open a security advisory on the repo,
-  contact **NuGet support** (<https://www.nuget.org/policies/Contact> / security@)
-  to request a hard delete (unlisting hides it but doesn't remove it), and note it
-  in `CHANGELOG.md` under **Security**.
+  then request a hard delete (unlisting hides it but doesn't remove it) —
+  [unlist it first](#unlist-a-package-version), file via the
+  [NuGet contact form](https://www.nuget.org/policies/Contact) and email
+  **support@nuget.org**, and for a platform-level compromise also report to the
+  Microsoft Security Response Center (**secure@microsoft.com** /
+  <https://msrc.microsoft.com/report>). Note it in `CHANGELOG.md` under **Security**.
 - Notify consumers via the advisory + release notes with the affected versions and
   the safe version to move to.
 

--- a/docs/DISASTER-RECOVERY.md
+++ b/docs/DISASTER-RECOVERY.md
@@ -1,0 +1,69 @@
+# Disaster Recovery — NuGet / GitHub account compromise
+
+Recovery actions after a credential compromise are time-critical and easy to
+fumble under stress. This runbook is the pre-written procedure. **Read it before
+you need it.** Work top-to-bottom; the ordering is deliberate (contain first,
+then eradicate, then communicate).
+
+> Scope: compromise of the NuGet.org account, the GitHub account/org, or the
+> machine/CI holding their credentials. Not for ordinary bugs or a bad release
+> (for a bad-but-not-malicious release, just [unlist](#unlist-a-package-version)
+> it and ship a fix).
+
+## 0. Assume breach — the accounts and keys involved
+
+| Asset | Where it lives | Blast radius if stolen |
+|---|---|---|
+| NuGet.org account | nuget.org login (protect with 2FA) | Publish/unlist any owned package |
+| NuGet API key / trusted-publishing | GitHub Actions secret / nuget.org trusted publisher policy | Publish new package versions |
+| GitHub account / PAT | github.com login, `~/.config/gh`, CI | Push code, edit workflows, releases, secrets |
+| Release signing cert (if adopted) | secure key store | Sign packages as us |
+
+## 1. Contain (minutes)
+
+1. **NuGet:** sign in → **Account → API Keys → Regenerate/Delete** every key.
+   If trusted publishing is used, remove the trusted-publisher policy for the repo.
+2. **GitHub:** **Settings → Password** (rotate) and **Developer settings → Personal
+   access tokens** (revoke all). **Settings → Sessions** → sign out everywhere.
+3. **Repo secrets:** **Settings → Secrets and variables → Actions** → rotate/delete
+   `NUGET_API_KEY` and anything else. Disable Actions if a workflow is actively
+   exfiltrating (`Settings → Actions → Disable`).
+4. If a **machine** was compromised, assume everything on it is exposed — rotate
+   from a known-clean device.
+
+## 2. Eradicate
+
+- Review recent **NuGet package versions** — [unlist](#unlist-a-package-version)
+  anything you didn't publish.
+- Review **GitHub**: recent commits, new/edited workflows, new collaborators,
+  new deploy keys, changed branch protection / rulesets, new releases. Revert
+  anything unexpected; remove rogue access.
+- Re-enable 2FA everywhere; require it for the org.
+
+## 3. Recover
+
+- Restore branch protection / rulesets from `repo-template` canonical.
+- Re-issue a clean `NUGET_API_KEY` (scoped to the `Wolfgang.*` package glob only,
+  "push new packages and versions") or re-establish trusted publishing.
+- Rebuild and re-release a known-good version from a clean checkout.
+
+## 4. Communicate
+
+- If a **malicious package version shipped**: open a security advisory on the repo,
+  contact **NuGet support** (<https://www.nuget.org/policies/Contact> / security@)
+  to request a hard delete (unlisting hides it but doesn't remove it), and note it
+  in `CHANGELOG.md` under **Security**.
+- Notify consumers via the advisory + release notes with the affected versions and
+  the safe version to move to.
+
+## Reference
+
+### Unlist a package version
+nuget.org → the package → **Manage → Listing** → uncheck the version → **Save**.
+Unlisting hides it from search/restore-by-default but existing lockfiles can still
+resolve it — for a malicious version, also request deletion via NuGet support.
+
+### Who has bypass / admin
+Repo admin(s) can admin-bypass branch protection (see
+[ADR-0001](adr/0001-vnext-protected-branching-model.md)). Keep the admin list
+minimal and 2FA-enforced.

--- a/docs/REPRODUCIBLE-BUILDS.md
+++ b/docs/REPRODUCIBLE-BUILDS.md
@@ -1,14 +1,14 @@
 # Reproducible builds — independent verification
 
-This package is built with reproducibility **inputs** enabled in
-`Directory.Build.props`:
+This package is built with reproducibility **inputs** enabled:
 
-- `<Deterministic>true</Deterministic>` — compiler output doesn't depend on wall
-  clock, machine paths, or ordering.
-- `<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>` (on CI) —
-  normalizes stored source paths.
-- SourceLink + `<EmbedUntrackedSources>` — the exact source is discoverable from
-  the symbols.
+- **Deterministic compilation** — `<Deterministic>` defaults to `true` for
+  SDK-style projects, so compiler output doesn't depend on the wall clock, machine
+  paths, or ordering.
+- `<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>` on CI (set in
+  `Directory.Build.props`) — normalizes stored source paths.
+- SourceLink + `<EmbedUntrackedSources>` (in `Directory.Build.props`) — the exact
+  source is discoverable from the symbols.
 
 That means a third party can rebuild the published package from source and confirm
 it matches — "trust, but verify". Here's how.
@@ -45,6 +45,21 @@ diff verify/mine.sha verify/theirs.sha && echo "✅ assemblies are byte-identica
 
 A clean `diff` proves the published binaries were built from this source with no
 injection in between.
+
+## If the hashes differ
+
+First rule out the benign causes below (a different SDK, or comparing the `.nupkg`
+zip instead of the assemblies). If the assemblies still differ after that, **treat
+it as a potential supply-chain discrepancy and report it**:
+
+- Open an issue at
+  <https://github.com/Chris-Wolfgang/Extensions-Logging-Data/issues> titled
+  "Reproducibility mismatch for v\<VERSION\>", including: the package version, your
+  **exact `dotnet --version`** and OS, and the two `sha256` lists (`verify/mine.sha`
+  and `verify/theirs.sha`) plus their `diff`.
+- If you believe the published package was tampered with (not just a toolchain
+  difference), also follow the reporting path in
+  [`SECURITY.md`](../SECURITY.md) / [`DISASTER-RECOVERY.md`](DISASTER-RECOVERY.md).
 
 ## Notes / caveats
 

--- a/docs/REPRODUCIBLE-BUILDS.md
+++ b/docs/REPRODUCIBLE-BUILDS.md
@@ -1,0 +1,59 @@
+# Reproducible builds — independent verification
+
+This package is built with reproducibility **inputs** enabled in
+`Directory.Build.props`:
+
+- `<Deterministic>true</Deterministic>` — compiler output doesn't depend on wall
+  clock, machine paths, or ordering.
+- `<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>` (on CI) —
+  normalizes stored source paths.
+- SourceLink + `<EmbedUntrackedSources>` — the exact source is discoverable from
+  the symbols.
+
+That means a third party can rebuild the published package from source and confirm
+it matches — "trust, but verify". Here's how.
+
+## Verify a published version yourself
+
+**Prerequisites:** the .NET SDK version the release was built with (see the release
+notes / `global.json` if present), and `git`.
+
+```bash
+# 1. Get the exact source for the version you want to verify.
+git clone https://github.com/Chris-Wolfgang/Extensions-Logging-Data.git
+cd Extensions-Logging-Data
+git checkout v<VERSION>          # e.g. v0.2.0 — the tag matches the package version
+
+# 2. Build the package the same way the release does.
+dotnet pack src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj \
+  -c Release -o ./verify
+
+# 3. Download the published package from NuGet.
+curl -sSL -o ./verify/published.nupkg \
+  "https://api.nuget.org/v3-flatcontainer/wolfgang.extensions.logging.data/<VERSION>/wolfgang.extensions.logging.data.<VERSION>.nupkg"
+
+# 4. Compare the compiled assembly inside each .nupkg. A .nupkg is a zip; the
+#    assembly is the reproducible artifact (the .nupkg envelope itself carries
+#    timestamps, so compare the DLLs, not the zip bytes).
+mkdir -p verify/mine verify/theirs
+unzip -oq verify/Wolfgang.Extensions.Logging.Data.<VERSION>.nupkg -d verify/mine
+unzip -oq verify/published.nupkg -d verify/theirs
+find verify/mine   -name '*.dll' -exec sha256sum {} \; | sed 's#verify/mine/##'   | sort > verify/mine.sha
+find verify/theirs -name '*.dll' -exec sha256sum {} \; | sed 's#verify/theirs/##' | sort > verify/theirs.sha
+diff verify/mine.sha verify/theirs.sha && echo "✅ assemblies are byte-identical"
+```
+
+A clean `diff` proves the published binaries were built from this source with no
+injection in between.
+
+## Notes / caveats
+
+- Compare the **assemblies** (`lib/**/*.dll`), not the `.nupkg` zip bytes — the
+  package envelope stores creation timestamps and isn't itself byte-reproducible.
+- Use the **same SDK major.minor**. A different Roslyn version can legitimately
+  produce different (but equally correct) IL.
+- The `net462` target may embed a framework-reference hash; if a specific TFM
+  differs, verify the others and file an issue noting the TFM.
+- This is the consumer-side counterpart to the repo's own build-reproducibility
+  check (which builds the same commit twice on CI and compares). If that check is
+  green and this local diff is clean, the chain from source to NuGet is verified.

--- a/docs/adr/0001-vnext-protected-branching-model.md
+++ b/docs/adr/0001-vnext-protected-branching-model.md
@@ -1,0 +1,47 @@
+# ADR-0001: vNext / protected-vNext release branching model
+
+- **Status:** Accepted
+- **Date:** 2026-07-13
+
+## Context
+
+The PR pipeline (`pr.yaml`) runs on `pull_request_target` targeting `main`, and a
+`Detect .NET Projects` guard **fails by design** whenever a PR touches a protected
+configuration file (`.github/workflows/*`, `Directory.Build.props`,
+`Directory.Build.targets`, `.editorconfig`, `BannedSymbols.txt`, `*.globalconfig`,
+`*.ruleset`). This makes protected-file PRs unmergeable without an admin bypass —
+intentional, so those files can't be weakened from within a PR.
+
+That is safe but awkward when a release bundles several changes, some of which
+touch protected files: every such PR would need its own admin-bypass, and the
+test stages never run (they `needs: detect-projects`, which fails).
+
+## Decision
+
+Accumulate a release on a per-cycle **`vNext`** integration branch, then land it
+through a short chain:
+
+```
+feature PRs ──▶ vNext ──▶ protected/vNext ──▶ main
+```
+
+- Feature PRs target **`vNext`**. Because `pr.yaml` only triggers on PRs whose base
+  is `main`, PRs into `vNext` don't run the guard at all — they merge normally.
+- `vNext → protected/vNext` is an integration PR (base isn't `main`, so no guard).
+- `protected/vNext → main` is the **single** admin-bypass hop that carries the
+  whole batch (protected files included) onto `main`.
+
+`vNext` and `protected/vNext` are **per-release-cycle**: created from `main` when a
+cycle starts, deleted after the batch lands. They are not long-lived branches.
+
+## Consequences
+
+- One admin-bypass per release instead of one per protected-file PR.
+- The trade-off: PRs targeting `vNext` get **no CI** (the stages are `main`-gated),
+  so real validation happens (a) locally before each push and (b) at the final
+  `protected/vNext → main` PR, where everything runs against `main`. Contributors
+  must verify locally — see `CONTRIBUTING.md`.
+- Do **not** treat `vNext` as permanent. After a release, leave it deleted; don't
+  auto-restore it. A new cycle recreates it from `main`.
+- A protected-file PR will always show `Detect .NET Projects: fail` and skipped
+  test stages — that is the guard working, not a broken pipeline.

--- a/docs/adr/0002-pinned-assemblyversion.md
+++ b/docs/adr/0002-pinned-assemblyversion.md
@@ -1,0 +1,34 @@
+# ADR-0002: Pin `AssemblyVersion` at `1.0.0.0`
+
+- **Status:** Accepted
+- **Date:** 2026-07-13 (documenting a decision first made for the v0.1.1 cycle)
+
+## Context
+
+The src project sets an explicit `<AssemblyVersion>1.0.0.0</AssemblyVersion>` while
+the package `<Version>` moves with every release (0.1.0, 0.1.1, 0.2.0, …). This
+looks stale and is a tempting "cleanup" target — surely the assembly version
+should track the package version?
+
+The package ships a `net462` target. On .NET Framework, assembly binding is
+**version-exact**: if `AssemblyVersion` changes on every minor/patch release, every
+consumer must recompile or add a binding redirect just to pick up a bug-fix. A
+regression that let the SDK derive `AssemblyVersion` from `<Version>` (dropping the
+pin) reached a release elsewhere in the fleet and broke .NET Framework consumers —
+the post-mortem is why this is now an explicit, documented decision.
+
+## Decision
+
+Keep `<AssemblyVersion>1.0.0.0</AssemblyVersion>` pinned. Carry the real release
+version in `<FileVersion>` (regex-stripped from `<Version>`) and
+`<InformationalVersion>` (auto-derived), which do **not** participate in binding.
+Bump `AssemblyVersion` only on a deliberate **breaking** API change.
+
+## Consequences
+
+- .NET Framework consumers get patch/minor updates without recompiles or binding
+  redirects.
+- `AssemblyVersion` no longer identifies the release — use `FileVersion` /
+  `InformationalVersion` / the NuGet package version for that.
+- **Do not** remove the pin or let it be SDK-derived, even though it looks stale.
+  If tooling or a template sync tries to drop it, restore it.

--- a/docs/adr/0003-anonymous-object-overload-not-aot-safe.md
+++ b/docs/adr/0003-anonymous-object-overload-not-aot-safe.md
@@ -1,0 +1,43 @@
+# ADR-0003: Anonymous-object `LogCommandText` overloads are not trim/AOT-safe
+
+- **Status:** Accepted
+- **Date:** 2026-07-13
+
+## Context
+
+`LogCommandText` has two parameter-supplying styles: an explicit
+`IReadOnlyDictionary<string, object?>` and a Dapper-style anonymous object
+(`new { id = 1 }`). The anonymous-object path reflects over the runtime type's
+public properties (`Type.GetProperties` + `PropertyInfo.GetValue`) to build the
+name/value map.
+
+Under IL trimming / Native AOT, the trimmer cannot statically see which properties
+a reflected-over type has, so it may remove them — turning the overload into a
+silent no-op (empty parameters). We evaluated annotating the parameter with
+`[DynamicallyAccessedMembers(PublicProperties)]` to make the trimmer preserve them,
+but that attribute is **only valid on `Type` / `string` parameters** — applying it
+to an `object` parameter is `IL2098`. There is no annotation that makes reflecting
+over an arbitrary `object`'s properties trim-safe.
+
+## Decision
+
+Mark the four anonymous-object `LogCommandText(..., object parameters, ...)`
+overloads (and the internal `ToDictionary(object)` / `BuildPropertyReader` helpers)
+`[RequiresUnreferencedCode]`. Consumers building trimmed / AOT apps get an `IL2026`
+warning directing them to the dictionary overload, which is trim/AOT-safe.
+`RequiresUnreferencedCodeAttribute` is polyfilled for the pre-net5 target
+frameworks (net462, netstandard2.0/2.1).
+
+The trim/AOT-safe surface (`LogDbConnection`, `LogDbCommand`, the dictionary
+`LogCommandText`) is verified by a `PublishAot` smoke consumer in CI.
+
+## Consequences
+
+- The library's AOT story is honest and enforced: the safe surface is verified;
+  the unsafe overload is flagged at the call site rather than failing silently.
+- Non-trimmed consumers are unaffected — `[RequiresUnreferencedCode]` produces no
+  warning outside trim/AOT analysis.
+- **Do not** "fix" the `IL2026` by adding `[DynamicallyAccessedMembers]` to the
+  `object` parameter — it is invalid there (`IL2098`). If a genuinely trim-safe
+  design is wanted, it requires a source-generator or an explicit dictionary API,
+  not an annotation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,33 @@
+# Architecture Decision Records
+
+This folder captures **non-obvious design decisions** — the ones whose rationale
+is easy to lose six months after the PR that introduced them. Each ADR records
+the *context*, the *decision*, and the *consequences* so a future maintainer (or
+you-in-six-months) doesn't re-derive the same trade-off poorly, or silently undo
+a deliberate choice.
+
+## When to write one
+
+Write an ADR when a decision is **not self-evident from the code** and would be
+tempting to "clean up" without knowing why it's there. Examples: a deliberate
+API-shape choice, a pinned version that looks stale, a banned API, a security
+posture, a branching/release convention. Routine, obvious choices don't need one.
+
+## How to add one
+
+1. Copy [`TEMPLATE.md`](TEMPLATE.md) to `NNNN-short-kebab-title.md`, using the
+   next free zero-padded number.
+2. Fill in Context / Decision / Consequences. Keep it short — a screenful.
+3. Set the status (`Proposed` → `Accepted`, later maybe `Superseded by ADR-XXXX`).
+4. Add a row to the index below.
+
+ADRs are **immutable once accepted** — don't rewrite history. If a decision
+changes, write a new ADR that supersedes the old one and update both statuses.
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](0001-vnext-protected-branching-model.md) | vNext / protected-vNext release branching model | Accepted |
+| [0002](0002-pinned-assemblyversion.md) | Pin `AssemblyVersion` at `1.0.0.0` | Accepted |
+| [0003](0003-anonymous-object-overload-not-aot-safe.md) | Anonymous-object `LogCommandText` overloads are not trim/AOT-safe | Accepted |

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,20 @@
+# ADR-NNNN: <short decision title>
+
+- **Status:** Proposed | Accepted | Superseded by ADR-XXXX
+- **Date:** YYYY-MM-DD
+
+## Context
+
+What is the situation, constraint, or problem that forces a decision? What
+options were on the table? Include the forces (performance, compatibility,
+security, maintainability) that pull in different directions.
+
+## Decision
+
+The choice that was made, stated plainly. "We will …".
+
+## Consequences
+
+What becomes easier and what becomes harder as a result. Include the accepted
+downsides — an ADR that lists only upsides is hiding something. Note anything a
+future maintainer must NOT do (e.g. "do not remove X — it looks stale but …").

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,24 @@
+# Migration guides
+
+When a **major** version ships with breaking changes (e.g. `0.x → 1.0`, or
+`1.x → 2.0`), consumers need a written upgrade path: what was renamed / removed /
+behaviourally changed, the replacement, and before/after code.
+
+No major version with breaking changes has shipped yet, so there are no migration
+guides here — only the **convention**, established now so it's ready when needed:
+
+## Convention
+
+- One file per major transition: `v{from}-to-v{to}.md` (e.g. `v1-to-v2.md`).
+- Start from [`TEMPLATE-major-version-migration.md`](TEMPLATE-major-version-migration.md).
+- Write it **as part of the PR that introduces the break**, not after release —
+  the author has the context then.
+- Link it from the `CHANGELOG.md` entry for that release and from the release notes.
+- SemVer reminder: breaking changes are only allowed in a **major** bump (and, for
+  `0.x`, a minor bump per SemVer's 0.x clause). If you're writing one of these for
+  a patch, something is wrong.
+
+## Index
+
+_None yet — the library is pre-1.0. The first entry lands with the first breaking
+major release._

--- a/docs/migrations/TEMPLATE-major-version-migration.md
+++ b/docs/migrations/TEMPLATE-major-version-migration.md
@@ -1,0 +1,41 @@
+# Migrating from v{FROM} to v{TO}
+
+> One-paragraph summary: who is affected, roughly how much work, and whether the
+> upgrade can be done incrementally.
+
+## At a glance
+
+| Change | Kind | Action |
+|---|---|---|
+| `OldApi(...)` | Renamed → `NewApi(...)` | Mechanical rename |
+| `SomeType.OldProp` | Removed | Use `NewProp` |
+| `Method(...)` default behaviour | Changed | Review call sites; pass X explicitly to keep old behaviour |
+
+## Breaking changes in detail
+
+### 1. `<what changed>`
+
+**Why:** <the reason — link the ADR or PR>.
+
+**Before:**
+
+```csharp
+// old usage
+```
+
+**After:**
+
+```csharp
+// new usage
+```
+
+## Non-breaking additions worth adopting
+
+- <new API> — <what it gives you>.
+
+## Upgrade checklist
+
+- [ ] Bump the package reference to `{TO}`.
+- [ ] Apply the renames/replacements above (the compiler flags most of them).
+- [ ] Re-run tests; review any changed-behaviour call sites.
+- [ ] Remove any workarounds that the new version makes unnecessary.

--- a/src/Wolfgang.Extensions.Logging.Data/Compatibility/TrimAnnotations.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/Compatibility/TrimAnnotations.cs
@@ -1,0 +1,34 @@
+// Polyfill for RequiresUnreferencedCodeAttribute, which the .NET 5+ BCL provides but
+// the older target frameworks (net462, netstandard2.0, netstandard2.1) do not. The IL
+// trimmer / Native AOT compiler match this attribute by full type name, so an internal
+// definition with the canonical name is recognized exactly as the framework type would
+// be. On net5.0+ (incl. net10.0) the real BCL type is used and this file compiles away.
+#if !NET5_0_OR_GREATER
+
+#pragma warning disable MA0048 // File name must match type name — this is a framework polyfill.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that the marked method uses functionality (here, reflection over a runtime
+    /// type's members) that cannot be statically analysed by the trimmer, so calling it from
+    /// a trimmed / Native AOT application is not guaranteed to be safe. Polyfill of the .NET 5+
+    /// framework attribute for older target frameworks.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false)]
+    internal sealed class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        public RequiresUnreferencedCodeAttribute(string message)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+
+        public string? Url { get; set; }
+    }
+}
+
+#pragma warning restore MA0048
+
+#endif

--- a/src/Wolfgang.Extensions.Logging.Data/DbCommandLoggerExtensions.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/DbCommandLoggerExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
@@ -43,6 +44,11 @@ public static class DbCommandLoggerExtensions
         "DbCommand CommandText={CommandText} Parameters={Parameters}";
 
     private const string RedactedValue = "***";
+
+    private const string ReflectionParametersTrimMessage =
+        "The anonymous-object parameter overload reflects over the runtime type's public " +
+        "properties, which the trimmer cannot statically preserve. In trimmed / Native AOT " +
+        "applications, pass an IReadOnlyDictionary<string, object?> instead.";
 
     /// <summary>
     /// Per-type cache of "read the public properties of an instance of this type into a
@@ -201,6 +207,7 @@ public static class DbCommandLoggerExtensions
     ///     new[] { "password" });
     /// </code>
     /// </example>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     public static void LogCommandText(this ILogger logger, string commandText, object parameters)
     {
         LogCommandText(logger, commandText, ToDictionary(parameters), Array.Empty<string>(), LogLevel.Information);
@@ -220,6 +227,7 @@ public static class DbCommandLoggerExtensions
     /// Thrown when <paramref name="logger"/>, <paramref name="commandText"/>, or
     /// <paramref name="parameters"/> is <see langword="null"/>.
     /// </exception>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     public static void LogCommandText(this ILogger logger, string commandText, object parameters, LogLevel level)
     {
         LogCommandText(logger, commandText, ToDictionary(parameters), Array.Empty<string>(), level);
@@ -244,6 +252,7 @@ public static class DbCommandLoggerExtensions
     /// <paramref name="parameters"/>, or <paramref name="excludedParameterNames"/> is
     /// <see langword="null"/>.
     /// </exception>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     public static void LogCommandText(this ILogger logger, string commandText, object parameters, IEnumerable<string> excludedParameterNames)
     {
         LogCommandText(logger, commandText, ToDictionary(parameters), excludedParameterNames, LogLevel.Information);
@@ -269,6 +278,7 @@ public static class DbCommandLoggerExtensions
     /// <paramref name="parameters"/>, or <paramref name="excludedParameterNames"/> is
     /// <see langword="null"/>.
     /// </exception>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     public static void LogCommandText(this ILogger logger, string commandText, object parameters, IEnumerable<string> excludedParameterNames, LogLevel level)
     {
         LogCommandText(logger, commandText, ToDictionary(parameters), excludedParameterNames, level);
@@ -411,6 +421,7 @@ public static class DbCommandLoggerExtensions
     /// <param name="parameters">The object to read. Must not be <see langword="null"/>.</param>
     /// <returns>A dictionary of property name to value.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="parameters"/> is <see langword="null"/>.</exception>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     internal static IReadOnlyDictionary<string, object?> ToDictionary(object parameters)
     {
         if (parameters is null)
@@ -436,6 +447,7 @@ public static class DbCommandLoggerExtensions
     /// Builds a delegate that reads the public readable instance properties of objects of the
     /// given <paramref name="type"/> into a dictionary. Called once per type via the cache.
     /// </summary>
+    [RequiresUnreferencedCode(ReflectionParametersTrimMessage)]
     private static Func<object, IReadOnlyDictionary<string, object?>> BuildPropertyReader(Type type)
     {
         var properties = type

--- a/src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj
+++ b/src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj
@@ -3,7 +3,7 @@
 		<TargetFrameworks>net462;netstandard2.0;netstandard2.1;net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-		<Version>0.2.0</Version>
+		<Version>0.3.0</Version>
 		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 		     do not need to recompile / add binding redirects on every minor/patch
 		     bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Fakes.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Fakes.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+
+namespace Wolfgang.Extensions.Logging.Data.AotSmoke;
+
+/// <summary>Counts log entries so the smoke can assert no call silently no-ops.</summary>
+internal sealed class CountingLogger : ILogger
+{
+    public int Count { get; private set; }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        _ = formatter(state, exception);   // render the template so any format break surfaces
+        Count++;
+    }
+}
+
+
+/// <summary>Minimal in-memory <see cref="DbConnection"/> — no provider, so the smoke's trim/AOT result is attributable to the library alone.</summary>
+internal sealed class FakeDbConnection : DbConnection
+{
+    [AllowNull]
+    public override string ConnectionString { get; set; } = "Server=localhost;Database=Test;User Id=sa;Password=secret";
+
+    public override string Database => "Test";
+
+    public override string DataSource => "localhost";
+
+    public override string ServerVersion => "1.0";
+
+    public override ConnectionState State => ConnectionState.Closed;
+
+    public override void ChangeDatabase(string databaseName) { }
+
+    public override void Close() { }
+
+    public override void Open() { }
+
+    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new NotSupportedException();
+
+    protected override DbCommand CreateDbCommand() => new FakeDbCommand { Connection = this };
+}
+
+
+internal sealed class FakeDbCommand : DbCommand
+{
+    private readonly FakeParameterCollection _parameters = new();
+
+    [AllowNull]
+    public override string CommandText { get; set; } = string.Empty;
+
+    public override int CommandTimeout { get; set; }
+
+    public override CommandType CommandType { get; set; }
+
+    public override bool DesignTimeVisible { get; set; }
+
+    public override UpdateRowSource UpdatedRowSource { get; set; }
+
+    protected override DbConnection? DbConnection { get; set; }
+
+    protected override DbParameterCollection DbParameterCollection => _parameters;
+
+    protected override DbTransaction? DbTransaction { get; set; }
+
+    public override void Cancel() { }
+
+    public override int ExecuteNonQuery() => throw new NotSupportedException();
+
+    public override object? ExecuteScalar() => throw new NotSupportedException();
+
+    public override void Prepare() { }
+
+    protected override DbParameter CreateDbParameter() => new FakeParameter();
+
+    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => throw new NotSupportedException();
+}
+
+
+internal sealed class FakeParameter : DbParameter
+{
+    public override DbType DbType { get; set; }
+
+    public override ParameterDirection Direction { get; set; }
+
+    public override bool IsNullable { get; set; }
+
+    [AllowNull]
+    public override string ParameterName { get; set; } = string.Empty;
+
+    public override int Size { get; set; }
+
+    [AllowNull]
+    public override string SourceColumn { get; set; } = string.Empty;
+
+    public override bool SourceColumnNullMapping { get; set; }
+
+    [AllowNull]
+    public override object Value { get; set; }
+
+    public override void ResetDbType() { }
+}
+
+
+internal sealed class FakeParameterCollection : DbParameterCollection
+{
+    private readonly List<DbParameter> _items = new();
+
+    public override int Count => _items.Count;
+
+    public override object SyncRoot => _items;
+
+    public override int Add(object value)
+    {
+        _items.Add((DbParameter)value);
+        return _items.Count - 1;
+    }
+
+    public override IEnumerator GetEnumerator() => _items.GetEnumerator();
+
+    protected override DbParameter GetParameter(int index) => _items[index];
+
+    protected override DbParameter GetParameter(string parameterName) => throw new NotSupportedException();
+
+    public override void AddRange(Array values) => throw new NotSupportedException();
+
+    public override void Clear() => _items.Clear();
+
+    public override bool Contains(object value) => throw new NotSupportedException();
+
+    public override bool Contains(string value) => throw new NotSupportedException();
+
+    public override void CopyTo(Array array, int index) => throw new NotSupportedException();
+
+    public override int IndexOf(object value) => throw new NotSupportedException();
+
+    public override int IndexOf(string parameterName) => throw new NotSupportedException();
+
+    public override void Insert(int index, object value) => throw new NotSupportedException();
+
+    public override void Remove(object value) => throw new NotSupportedException();
+
+    public override void RemoveAt(int index) => throw new NotSupportedException();
+
+    public override void RemoveAt(string parameterName) => throw new NotSupportedException();
+
+    protected override void SetParameter(int index, DbParameter value) => throw new NotSupportedException();
+
+    protected override void SetParameter(string parameterName, DbParameter value) => throw new NotSupportedException();
+}

--- a/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Program.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Program.cs
@@ -1,0 +1,47 @@
+// Native AOT / trimming smoke test for the AOT-safe public surface of
+// Wolfgang.Extensions.Logging.Data. Published with PublishAot + PublishTrimmed
+// (see the .csproj) and run by CI: a trim/AOT-unsafe regression makes the
+// analyzers warn (TreatWarningsAsErrors → build fails), and a runtime break
+// (MissingMethodException / NotSupportedException / silent no-op) makes this
+// program exit non-zero.
+//
+// The anonymous-object LogCommandText overloads are DELIBERATELY not exercised
+// here: they reflect over the parameter's runtime type and are marked
+// [RequiresUnreferencedCode] — documented as not AOT/trim-safe. The
+// IReadOnlyDictionary overloads are the AOT-safe equivalent and are covered.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Wolfgang.Extensions.Logging.Data;
+using Wolfgang.Extensions.Logging.Data.AotSmoke;
+
+var logger = new CountingLogger();
+
+using var connection = new FakeDbConnection();
+logger.LogDbConnection(connection);
+logger.LogDbConnection(connection, LogLevel.Debug);
+
+using var command = connection.CreateCommand();
+command.CommandText = "SELECT * FROM Users WHERE Id = @id AND Pw = @password";
+logger.LogDbCommand(command);
+logger.LogDbCommand(command, LogLevel.Debug);
+logger.LogDbCommand(command, new[] { "password" });
+logger.LogDbCommand(command, new[] { "password" }, LogLevel.Debug);
+
+var parameters = new Dictionary<string, object?> { ["@id"] = 1, ["@password"] = "secret" };
+logger.LogCommandText("SELECT ...", parameters);
+logger.LogCommandText("SELECT ...", parameters, LogLevel.Debug);
+logger.LogCommandText("SELECT ...", parameters, new[] { "password" });
+logger.LogCommandText("SELECT ...", parameters, new[] { "password" }, LogLevel.Debug);
+
+// 10 AOT-safe calls above — each must produce exactly one log entry. A silent
+// no-op (e.g. trimmed members) would drop the count.
+const int expected = 10;
+if (logger.Count != expected)
+{
+    System.Console.Error.WriteLine($"FAIL: expected {expected} log entries, got {logger.Count}.");
+    return 1;
+}
+
+System.Console.WriteLine($"OK: AOT-safe surface produced {logger.Count} log entries under Native AOT.");
+return 0;

--- a/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Wolfgang.Extensions.Logging.Data.AotSmoke.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Wolfgang.Extensions.Logging.Data.AotSmoke.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+
+    <!-- The whole point of this project: enable the trim + Native AOT analyzers so
+         any trim/AOT regression in the library's AOT-safe surface fails the build,
+         and let `dotnet publish` produce a real native binary the CI step runs. -->
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <IsPackable>false</IsPackable>
+    <!-- Not a test project (no test SDK) — it is a compile+publish+run smoke. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.Logging.Data\Wolfgang.Extensions.Logging.Data.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+  </ItemGroup>
+</Project>

--- a/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Wolfgang.Extensions.Logging.Data.AotSmoke.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Wolfgang.Extensions.Logging.Data.AotSmoke.csproj
@@ -10,6 +10,9 @@
          any trim/AOT regression in the library's AOT-safe surface fails the build,
          and let `dotnet publish` produce a real native binary the CI step runs. -->
     <PublishAot>true</PublishAot>
+    <!-- PublishAot implies trimming, but set it explicitly so the project file
+         matches the documented intent and the trim analyzers are unambiguous. -->
+    <PublishTrimmed>true</PublishTrimmed>
     <IsAotCompatible>true</IsAotCompatible>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
Final hop feature → vNext → protected/vNext → main.

Contents:
- #94 Trim/Native AOT — RequiresUnreferencedCode on the anonymous-object overloads + attribute polyfill, AOT smoke consumer + aot-smoke CI job. (src change → 0.3.0 MINOR release warranted)
- #160 docs — ADRs, DR runbook, migration convention, reproducible-build verification (closes #100/#101/#102/#106)
- #97 reproducible-build verification workflow (closes #97)
- #90 SLSA build-provenance attestation (Refs #90; signing still needs a cert)

Requires admin-bypass: touches protected workflow files (pr.yaml, release.yaml, reproducible-build.yaml) so Detect .NET Projects fails by design and stages skip. Verified locally + reviewed across the source PRs. The aot-smoke and reproducible-build jobs run live here for the first time. Nothing publishes on merge.