### PR TITLE
ci: protected workflow changes for the 0.3.0 batch (admin-bypass)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -353,6 +353,67 @@ jobs:
           echo "✅ No error-severity InspectCode findings."
 
   # ============================================================================
+  # AOT SMOKE: publish a Native-AOT + trimmed consumer of the library and run it.
+  # The trim/AOT analyzers (TreatWarningsAsErrors) fail the build on any regression
+  # to the AOT-safe surface; running the native binary catches runtime breaks
+  # (MissingMethod / NotSupported / silent no-op). Parallel to the test stages.
+  # ============================================================================
+  aot-smoke:
+    name: "Native AOT smoke"
+    runs-on: ubuntu-latest
+    needs: detect-projects
+    # Same-repo PRs only — builds PR code under pull_request_target (see the
+    # inspectcode job for the rationale).
+    if: >-
+      github.repository != 'Chris-Wolfgang/repo-template'
+      && needs.detect-projects.outputs.has-projects == 'true'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install Native AOT prerequisites
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Find the AOT smoke project
+        id: smoke
+        run: |
+          PROJ=$(find . -name '*.AotSmoke.csproj' | head -n1)
+          if [ -z "$PROJ" ]; then
+            echo "No *.AotSmoke.csproj found — skipping."
+            echo "found=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Smoke project: $PROJ"
+            echo "found=$PROJ" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish Native AOT (trim + AOT analyzers gate the build)
+        if: steps.smoke.outputs.found != ''
+        run: dotnet publish "${{ steps.smoke.outputs.found }}" -c Release -r linux-x64
+
+      - name: Run the published native binary
+        if: steps.smoke.outputs.found != ''
+        run: |
+          BIN=$(find "$(dirname "${{ steps.smoke.outputs.found }}")/bin" -type f -name '*.AotSmoke' -path '*publish*' | head -n1)
+          if [ -z "$BIN" ]; then
+            echo "::error::Native AOT binary not produced."
+            exit 1
+          fi
+          echo "Running: $BIN"
+          "$BIN"
+
+  # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
   test-linux-core:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -350,6 +350,10 @@ jobs:
     name: Pack & Validate NuGet
     needs: validate-release
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write        # SLSA build-provenance attestation (OIDC)
+      attestations: write    # SLSA build-provenance attestation
     outputs:
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
@@ -571,6 +575,22 @@ jobs:
             }
           }
 
+
+      # SLSA build-provenance attestation: cryptographically links each .nupkg to
+      # this repo + commit + workflow run, so a consumer can verify (via
+      # `gh attestation verify <nupkg> --repo Chris-Wolfgang/Extensions-Logging-Data`)
+      # that the package was built here and not injected downstream. Complements the
+      # SBOM above. (Author signing with a certificate is a separate follow-up.)
+      - name: Attest build provenance (SLSA)
+        if: steps.check-packages.outputs.has-packages == 'true'
+        uses: actions/attest-build-provenance@v2
+        with:
+          # Attest every shipped artifact: the packages, their symbol packages,
+          # and the CycloneDX SBOMs generated above.
+          subject-path: |
+            nuget-packages/*.nupkg
+            nuget-packages/*.snupkg
+            nuget-packages/*.bom.json
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v7

--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -1,0 +1,125 @@
+# ============================================================================
+# Reproducible-build verification. Determinism is the SDK default for SDK-style
+# projects, and Directory.Build.props adds the remaining reproducibility inputs
+# (ContinuousIntegrationBuild path-normalization on CI, SourceLink,
+# EmbedUntrackedSources). This workflow VERIFIES the output: it builds the same
+# commit twice PER OS (ubuntu + windows) and fails if a given OS's two builds are
+# not byte-identical. Consumers reproduce the same check from source — see
+# docs/REPRODUCIBLE-BUILDS.md (added alongside this workflow).
+#
+# Note: the gate is per-OS determinism, not cross-OS byte-identity. Cross-OS
+# byte-identical assemblies (esp. PDBs and the net462 target) are not reliably
+# achievable, which is why the acceptance criteria hedge "different OS where
+# possible" — building on both OSes proves each is internally deterministic.
+# ============================================================================
+name: Reproducible Build
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: "Build ${{ matrix.os }} (attempt ${{ matrix.attempt }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        attempt: [1, 2]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build (Release, deterministic)
+        shell: bash
+        run: |
+          # Resolve the solution explicitly (no bare `dotnet build`) so a repo with
+          # more than one solution/project at the root can't fail on CLI
+          # disambiguation. `./`-prefixed glob is dash-safe; guard the no-match case.
+          SLN=""
+          for candidate in ./*.slnx ./*.sln; do
+            if [ -e "$candidate" ]; then SLN="$candidate"; break; fi
+          done
+          if [ -z "$SLN" ]; then
+            echo "::error::No .slnx or .sln at repo root."
+            exit 1
+          fi
+          echo "Building: $SLN"
+          # ContinuousIntegrationBuild normalizes stored source paths so two CI
+          # runs of the same commit on the same OS produce identical output.
+          dotnet build "$SLN" -c Release -p:ContinuousIntegrationBuild=true
+
+      - name: Hash the built Wolfgang.* artifacts
+        shell: bash
+        run: |
+          # Hash both the assemblies and their symbols (.dll + .pdb) so a symbol
+          # regression is caught too. Key by <tfm>/<file> so the two attempts line
+          # up regardless of path ordering.
+          : > hashes.txt
+          while IFS= read -r -d '' f; do
+            key=$(echo "$f" | sed -E 's#.*/bin/Release/##')
+            echo "$(sha256sum "$f" | cut -d' ' -f1)  $key" >> hashes.txt
+          done < <(find src -path '*/bin/Release/*' \( -name 'Wolfgang.Extensions.Logging.Data*.dll' -o -name 'Wolfgang.Extensions.Logging.Data*.pdb' \) -print0)
+          sort -o hashes.txt hashes.txt
+
+          # Fail loudly if nothing was hashed — otherwise an empty file would make
+          # the compare job pass vacuously (e.g. if outputs move or a project is renamed).
+          count=$(wc -l < hashes.txt)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No Wolfgang.* build artifacts were found to hash — the find pattern or output layout changed."
+            exit 1
+          fi
+          echo "=== ${{ matrix.os }} attempt ${{ matrix.attempt }}: $count artifacts ==="
+          cat hashes.txt
+
+      - name: Upload hashes
+        uses: actions/upload-artifact@v4
+        with:
+          name: hashes-${{ matrix.os }}-${{ matrix.attempt }}
+          path: hashes.txt
+          retention-days: 3
+
+  compare:
+    name: "Compare (per-OS determinism)"
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download all hashes
+        uses: actions/download-artifact@v4
+        with:
+          path: hashes
+
+      - name: Assert each OS is deterministic
+        shell: bash
+        run: |
+          rc=0
+          for os in ubuntu-latest windows-latest; do
+            a="hashes/hashes-$os-1/hashes.txt"
+            b="hashes/hashes-$os-2/hashes.txt"
+            if [ ! -s "$a" ] || [ ! -s "$b" ]; then
+              echo "::error::Missing or empty hashes for $os."
+              rc=1
+              continue
+            fi
+            if diff -u "$a" "$b"; then
+              echo "✅ $os: two builds of the same commit are byte-identical."
+            else
+              echo "::error::$os build is NOT reproducible — assembly/symbol hashes differ between two builds of the same commit (diff above)."
+              rc=1
+            fi
+          done
+          exit "$rc"


### PR DESCRIPTION
The **protected-files-only** half of the 0.3.0 release batch (replaces the over-broad #164).

## Files (3 — all protected)
- `.github/workflows/pr.yaml` — the `aot-smoke` job (#94) + the hardened `inspectcode` job
- `.github/workflows/release.yaml` — SLSA build-provenance attestation (#90)
- `.github/workflows/reproducible-build.yaml` — new reproducibility-verification workflow (#97)

## Requires admin-bypass
`Detect .NET Projects` fails by design on protected files, stages skip. Reviewed as the source PRs (#151 hardened inspectcode, #90 attestation, #97 reproducible-build) with all threads resolved; validated locally (actionlint + zizmor clean, determinism verified).

## Merge ordering
Merge the **companion non-protected PR first** (it puts the `AotSmoke` project + `src` on `main`), then admin-bypass this one — so the `aot-smoke` job has the project it runs.