### PR TITLE
ci(release): migrate NuGet publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -703,6 +703,9 @@ jobs:
     needs: [pack-and-validate, verify-docs-build]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
+    permissions:
+      id-token: write   # required for OIDC token issuance to nuget.org
+      contents: read
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -722,22 +725,16 @@ jobs:
           name: nuget-packages
           path: ./packages
 
-      - name: Validate NuGet API key
-        shell: pwsh
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          if ([string]::IsNullOrEmpty($env:NUGET_API_KEY)) {
-            Write-Error "❌ NUGET_API_KEY secret not configured!"
-            Write-Host "Please add it in: Repository Settings → Secrets and variables → Actions → New repository secret"
-            exit 1
-          }
-          Write-Host "✅ NUGET_API_KEY is configured" -ForegroundColor Green
+      - name: NuGet login (OIDC → temporary API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        id: nuget-login
+        with:
+          user: Chris-Wolfgang
 
       - name: Publish to NuGet
         shell: pwsh
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           $packages = Get-ChildItem -Path './packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
           


### PR DESCRIPTION
## Scope

Migrate `.github/workflows/release.yaml` off `secrets.NUGET_API_KEY` and onto NuGet Trusted Publishing (OIDC), per #167. Every release now exchanges the workflow's GitHub OIDC token for an ephemeral (~1h) push key via `NuGet/login@v1` — no long-lived key on GitHub or nuget.org.

## Changes (publish-nuget job only)

- Add job `permissions: { id-token: write, contents: read }`
- Remove the "Validate NuGet API key" step (no repo secret to check anymore)
- Add "NuGet login (OIDC → temporary API key)" step — `NuGet/login@8d196754…​ # v1` (SHA-pinned), `id: nuget-login`, `user: Chris-Wolfgang`
- Publish step keys off `steps.nuget-login.outputs.NUGET_API_KEY` (ephemeral step output), not `secrets.NUGET_API_KEY`

Matches the canonical shape on `Etl-DbClient` `main`.

## ⚠️ Prerequisite before merging / next release

The nuget.org **Trusted Publishing policy must exist for BOTH packages** this repo ships, or the next release fails auth:

- `Wolfgang.Extensions.Logging.Data`
- `Wolfgang.Extensions.Logging.Data.EntityFramework6`

(Package page → Manage → Trusted Publishing → owner `Chris-Wolfgang`, repo `Extensions-Logging-Data`, workflow `.github/workflows/release.yaml`.)

`release.yaml` only fires on `release: published`, so merging this early is safe — it takes effect at the **next tag (v0.4.0)**.

## Merge / post-merge

- `release.yaml` is a **protected file** → the `Detect .NET Projects` guard will fail; merge via **admin-bypass** (`protected-file-pr-split`). No other jobs are affected.
- After the **first successful OIDC release**: delete the `NUGET_API_KEY` repo secret, and update the DR appendix issue #102 with the finalized Release-path line.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)
