### PR TITLE
ci(inspectcode): .DotSettings noise-floor + remove redundant usings (#136)

### DIFF
--- a/Extensions-Logging-Data.slnx.DotSettings
+++ b/Extensions-Logging-Data.slnx.DotSettings
@@ -1,0 +1,44 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<!--
+	  ReSharper InspectCode noise-floor (see issue #136).
+
+	  Purpose: silence InspectCode inspections that are either (a) already covered
+	  and gated by the build's Roslyn analyzer stack (Meziantou, SonarAnalyzer,
+	  Roslynator, AsyncFixer, VS.Threading, BannedApiAnalyzers, .NET SDK analyzers,
+	  PublicApiAnalyzers) — double-reporting them here adds no signal — or (b) known
+	  false positives on this repo's multi-TFM layout. The goal is 0 noise findings
+	  on a clean main so the first error after the job lands is always actionable.
+
+	  Only error-severity findings gate merge (pr.yaml `inspectcode` job); these
+	  entries drop the corresponding warnings from Code Scanning entirely.
+
+	  This is the proving-ground profile for the canonical repo-template rollout
+	  (repo-template#431). Keep additions justified and grouped.
+	-->
+
+	<!-- Redundant-code style rules — covered in-build by Roslynator / IDE00xx and
+	     .editorconfig. RedundantUsingDirective in particular is a FALSE POSITIVE on
+	     the src library project: <ImplicitUsings> is enabled only for net10.0, so
+	     explicit System usings are REQUIRED on net462/netstandard2.0/2.1 but look
+	     redundant to InspectCode (which analyses a single TFM). -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantNameQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCast/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+	<!-- Nullability — owned by the Roslyn nullable reference-type analysis, not R#. -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReturnTypeCanBeNotNullable/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantNullableFlowAttribute/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+	<!-- Public-API false positive: R# cannot see external consumers of a library's
+	     public auto-properties, so it reports them as unused (.Global variant). -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+	<!-- Roslyn / Sonar analyzer diagnostics re-run by InspectCode. These are already
+	     enforced (or intentionally dormant, e.g. PublicApiAnalyzers RS0016/RS0037)
+	     by the in-build analyzer stack; suppress the InspectCode double-report. -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RS0016/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RS0037/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=S3267/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=S3220/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=S2068/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+</wpf:ResourceDictionary>

--- a/Extensions-Logging-Data.slnx.DotSettings
+++ b/Extensions-Logging-Data.slnx.DotSettings
@@ -25,9 +25,17 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantNameQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCast/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 
-	<!-- Nullability — owned by the Roslyn nullable reference-type analysis, not R#. -->
+	<!-- Nullability — owned by the Roslyn nullable reference-type analysis, not R#.
+	     The *AccordingTo(Nullable)APIContract rules flag defensive null-checks on
+	     non-null-annotated parameters; those checks are INTENTIONAL in a library that
+	     is called from nullable-oblivious / older-TFM code where callers can still
+	     pass null despite the annotation. -->
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReturnTypeCanBeNotNullable/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantNullableFlowAttribute/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=NullnessAnnotationConflictWithJetBrainsAnnotations/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConditionalAccessQualifierIsNonNullableAccordingToAPIContract/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 
 	<!-- Public-API false positive: R# cannot see external consumers of a library's
 	     public auto-properties, so it reports them as unused (.Global variant). -->
@@ -36,6 +44,7 @@
 	<!-- Roslyn / Sonar analyzer diagnostics re-run by InspectCode. These are already
 	     enforced (or intentionally dormant, e.g. PublicApiAnalyzers RS0016/RS0037)
 	     by the in-build analyzer stack; suppress the InspectCode double-report. -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MA0009/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RS0016/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RS0037/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=S3267/@EntryIndexedValue">DO_NOT_SHOW</s:String>

--- a/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/DbCommandLoggerExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/DbCommandLoggerExtensionsBenchmarks.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Wolfgang.Extensions.Logging.Data;
 
 namespace Wolfgang.Extensions.Logging.Data.Benchmarks;
 

--- a/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/DbConnectionLoggerExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.Logging.Data.Benchmarks/DbConnectionLoggerExtensionsBenchmarks.cs
@@ -4,7 +4,6 @@ using System.Data.Common;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Wolfgang.Extensions.Logging.Data;
 
 namespace Wolfgang.Extensions.Logging.Data.Benchmarks;
 

--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/LoggingCommandInterceptor.cs
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/LoggingCommandInterceptor.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Entity.Infrastructure.Interception;
 using Microsoft.Extensions.Logging;
-using Wolfgang.Extensions.Logging.Data;
 
 namespace Wolfgang.Extensions.Logging.Data.EntityFramework6;
 

--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/LoggingConnectionInterceptor.cs
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/LoggingConnectionInterceptor.cs
@@ -3,7 +3,6 @@ using System.Data;
 using System.Data.Common;
 using System.Data.Entity.Infrastructure.Interception;
 using Microsoft.Extensions.Logging;
-using Wolfgang.Extensions.Logging.Data;
 
 namespace Wolfgang.Extensions.Logging.Data.EntityFramework6;
 

--- a/src/Wolfgang.Extensions.Logging.Data/Compatibility/TrimAnnotations.cs
+++ b/src/Wolfgang.Extensions.Logging.Data/Compatibility/TrimAnnotations.cs
@@ -7,6 +7,8 @@
 
 #pragma warning disable MA0048 // File name must match type name — this is a framework polyfill.
 
+// ReSharper disable once CheckNamespace — the polyfill MUST live in the BCL's namespace
+// so the trimmer/AOT compiler matches it by full type name; folder layout is irrelevant.
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>

--- a/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Fakes.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Fakes.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;

--- a/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Program.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.AotSmoke/Program.cs
@@ -10,7 +10,6 @@
 // [RequiresUnreferencedCode] — documented as not AOT/trim-safe. The
 // IReadOnlyDictionary overloads are the AOT-safe equivalent and are covered.
 
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Wolfgang.Extensions.Logging.Data;
 using Wolfgang.Extensions.Logging.Data.AotSmoke;

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/DocExampleCompilationTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Docs/DocExampleCompilationTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/DbConnectionLoggerIntegrationTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/DbConnectionLoggerIntegrationTests.cs
@@ -1,8 +1,6 @@
-using System.Collections.Generic;
 using System.Data;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
-using Wolfgang.Extensions.Logging.Data;
 
 namespace Wolfgang.Extensions.Logging.Data.Tests.Integration;
 

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/DbConnectionLoggerIntegrationTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Integration/DbConnectionLoggerIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/AllocationFreeHotPathTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/AllocationFreeHotPathTests.cs
@@ -1,6 +1,5 @@
 #if NET8_0_OR_GREATER
 
-using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbCommandLoggerExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbCommandLoggerExtensionsTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
 

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbCommandLoggerExtensions_LogDbCommandTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbCommandLoggerExtensions_LogDbCommandTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Data;
 using System.Data.Common;
 using Microsoft.Extensions.Logging;
 using Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbConnectionLoggerExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/DbConnectionLoggerExtensionsTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Data;
 using System.Data.Common;
 using Microsoft.Extensions.Logging;

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/GlobalizationInvarianceTests.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/GlobalizationInvarianceTests.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Data.Common;
 using System.Globalization;
-using System.Threading;
-using Microsoft.Extensions.Logging;
 using Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;
 
 namespace Wolfgang.Extensions.Logging.Data.Tests.Unit;

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbCommand.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbCommand.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbConnection.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/FakeDbConnection.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Data;
 using System.Data.Common;
 

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/LogEntry.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/LogEntry.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/RecordingLogger.cs
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/TestHelpers/RecordingLogger.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace Wolfgang.Extensions.Logging.Data.Tests.Unit.TestHelpers;


### PR DESCRIPTION
## Scope

Advances #136 by establishing the ReSharper InspectCode **noise-floor** so a clean `main` yields ~0 noise findings — the last outstanding piece for this repo (the gating `inspectcode` job itself already landed). ELD is the proving ground for the canonical `repo-template` profile (repo-template#431).

## Baseline (open InspectCode alerts on main)

| n | rule | disposition |
|---|---|---|
| 33 | `RedundantUsingDirective` | 29 removed in code; 4 in src lib suppressed (see below) |
| 33 | `RS0016` / 7 `RS0037` | Suppress — PublicApiAnalyzers double-report (dormant in-build, hand-maintained) |
| 10 | `RedundantNameQualifier` | Suppress — covered by IDE0001/Roslynator |
| 5 | `UnusedAutoPropertyAccessor.Global` | Suppress — public-API false positive (R# can't see external consumers) |
| 4 | `RedundantCast` | Suppress — covered by IDE0004 |
| 3 | `ReturnTypeCanBeNotNullable` / 2 `RedundantNullableFlowAttribute` | Suppress — nullable is Roslyn-owned |
| 1 ea | `S3267` / `S3220` / `S2068` | Suppress — Sonar double-report (gated in-build) |

## Changes

**1. `Extensions-Logging-Data.slnx.DotSettings`** (new) — the solution-shared profile `jb inspectcode` auto-loads (the job passes no `--profile`). Silences the double-reports and covered-by-Roslyn style rules above. Not a protected file → this PR gets full CI, and the `inspectcode` job re-runs with the new profile and re-uploads SARIF (self-validating).

**2. Removed 29 genuinely-redundant `using` directives** (`RedundantUsingDirective`) across tests, benchmarks, EF6, and the AOT smoke — implicit-global duplicates (ImplicitUsings projects) and enclosing-namespace `using Wolfgang.Extensions.Logging.Data;` imports. Mostly test files.

## What is deliberately NOT changed

The 4 `RedundantUsingDirective` hits in the **src library** (`DbCommandLoggerExtensions.cs`, `DbConnectionLoggerExtensions.cs`) are **kept**: `<ImplicitUsings>` is enabled only for `net10.0` there, so those `System` / `System.Collections.Generic` / `System.Linq` usings are **required** on net462 / netstandard2.0 / 2.1. InspectCode analyses a single TFM (net10.0) and reports them as redundant — a multi-TFM false positive. They're covered by the `RedundantUsingDirective` suppression rather than removed. (Confirmed: removing them breaks the net462 build with CS0246.)

## Validation

All changed projects build clean (`-c Release`) on their strictest TFM:
- src EF6, Tests.Unit → **net462**
- AotSmoke, Docs, Integration, benchmarks → net10.0

## Not in this PR (follow-ups on #136)

- Making **"ReSharper InspectCode" a required status check** on `main` (branch-ruleset change — maintainer decision).
- Landing the profile canonically in `repo-template` and fanning out (repo-template#431).

Refs #136
