### PR TITLE
docs(security): add Release path & compromise scope appendix (#102)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,15 @@ We will acknowledge your report within 48 hours and provide an estimated timelin
 
 Your help is greatly appreciated!
 Responsible disclosure of security vulnerabilities helps protect our entire community.
+
+## Release path & compromise scope
+
+Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook.
+
+- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` in `.github/workflows/release.yaml`. The workflow mints an ephemeral push token per run via OIDC — the release path does not depend on a long-lived API key stored in GitHub secrets or on the NuGet account. During an incident, check the NuGet account for any long-lived API keys anyway (they can be created outside of CI) and delete anything you don't recognize.
+- **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account level (the OIDC identity is `Chris-Wolfgang/Extensions-Logging-Data`).
+- **Owner**: @Chris-Wolfgang.
+- **Downstream consumers**: none known within the Wolfgang.* fleet; the in-repo `Wolfgang.Extensions.Logging.Data.EntityFramework6` companion package depends on the core package. Unknown external consumers may exist on nuget.org.
+- **Package coordinates for unlisting** (this repo ships two packages):
+  - `Wolfgang.Extensions.Logging.Data` — https://www.nuget.org/packages/Wolfgang.Extensions.Logging.Data/
+  - `Wolfgang.Extensions.Logging.Data.EntityFramework6` — https://www.nuget.org/packages/Wolfgang.Extensions.Logging.Data.EntityFramework6/


### PR DESCRIPTION
## Scope

Land the "Release path & compromise scope" appendix in `SECURITY.md` (#102) — the load-bearing per-repo facts a maintainer needs if the release identity is compromised. Canonical shape from Etl-DbClient; generic incident-response steps deliberately NOT duplicated (GitHub/NuGet docs are authoritative and update faster).

Now unblocked: #102 was blocked by #167, and the **OIDC / Trusted Publishing migration merged** (PR #168), so the Release-path bullet names OIDC to stay fleet-consistent.

## Filled-in values

- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` — no long-lived key
- **Fallback**: none; OIDC identity `Chris-Wolfgang/Extensions-Logging-Data`
- **Owner**: @Chris-Wolfgang
- **Downstream**: none known in the Wolfgang.* fleet (the in-repo EF6 companion depends on core); unknown external consumers may exist
- **Package coordinates** (BOTH shipped packages): `Wolfgang.Extensions.Logging.Data` + `Wolfgang.Extensions.Logging.Data.EntityFramework6`, with nuget.org URLs

## Notes

Docs-only — no version bump. No `[fill in]` placeholders remain.

Closes #102
