### PR TITLE
chore(security): suppress won't-fix Scorecard rules at the SARIF layer (#184)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -45,6 +45,94 @@ jobs:
           # cross-repo trend data. Public repos only; publishes no source code.
           publish_results: true
 
+      # Suppress Scorecard checks whose findings are known won't-fix or false
+      # positives for this repo, BEFORE the SARIF reaches code-scanning. Doing
+      # it here (rather than dismissing individual alerts) makes the suppression
+      # durable across weekly re-runs — Scorecard emits a fresh SARIF each run,
+      # and fingerprint drift means dismissals don't always survive.
+      #
+      # Suppressed rule IDs (whole rule):
+      #   DangerousWorkflowID  — pr.yaml deliberately uses pull_request_target
+      #                          so the workflow definition comes from trusted
+      #                          main (a PR branch can't weaken its own CI).
+      #                          The "Detect .NET Projects" step re-fetches
+      #                          every protected config file from main before
+      #                          any build runs. See the pr.yaml SECURITY NOTE
+      #                          header (and .github/zizmor.yml, which also
+      #                          waives dangerous-triggers on pr.yaml for the
+      #                          same reason).
+      #   BranchProtectionID   — solo-maintainer repo; approver / codeowner /
+      #                          last-push-approval would force admin-bypass on
+      #                          every PR without adding a real review gate.
+      #   CodeReviewID         — same underlying reason (solo maintainer).
+      #   CIIBestPracticesID   — external bestpractices.dev registration; not
+      #                          in scope for CI, tracked separately if pursued.
+      #   FuzzingID            — no fuzz-test integration in this repo (a small
+      #                          adapter library over Microsoft.Extensions.Logging).
+      #                          Scorecard's heuristic detects only OSS-Fuzz /
+      #                          ClusterFuzzLite integrations.
+      #
+      # Suppressed PinnedDependenciesID sub-checks (partial rule):
+      #   nugetCommand — `dotnet tool install` (ReSharper CLT, reportgenerator,
+      #                  DevSkim) and `dotnet restore` are not hash-pinned. Every
+      #                  csproj already uses explicit PackageReference Versions
+      #                  ("no floating"), Dependabot's `nuget` ecosystem bumps
+      #                  transitives weekly, and no repo in the fleet ships
+      #                  packages.lock.json. Adopting `--locked-mode` fleet-wide
+      #                  is a separate decision.
+      #   pipCommand   — future-proofing: no pip installs today, but if any get
+      #                  added (semgrep, zizmor requirements.txt, etc.) they'd
+      #                  be dev-time SAST tooling installed from PyPI over
+      #                  HTTPS with signed packages. Hash-pinning via
+      #                  requirements.txt + --require-hashes needs a pip-tools
+      #                  workflow not adopted fleet-wide.
+      # gitHubAction rows are NOT suppressed: any regression to an @vN action
+      # ref without a SHA pin should still fire on the next scan.
+      #
+      # NOT suppressed but low (real actionable signal):
+      #   CITestsID (9/10) — recover the last 10% by re-running any failed CI
+      #                      on the outstanding PRs so every commit has a
+      #                      passing CI record.
+      #   SASTID   (9/10) — same shape, one older commit escaped CodeQL when
+      #                     the workflow was first introduced.
+      #
+      # The scorecard.dev score published to the transparency log (README badge)
+      # still counts every check; this only trims the code-scanning-tab noise.
+      - name: Filter suppressed findings from SARIF
+        shell: bash
+        env:
+          SUPPRESSED_RULES: 'DangerousWorkflowID BranchProtectionID CodeReviewID CIIBestPracticesID FuzzingID'
+          # Substrings matched against each PinnedDependenciesID result's
+          # message text. Order-independent; a single match suppresses.
+          SUPPRESSED_PIN_KINDS: 'nugetCommand not pinned|pipCommand not pinned'
+        run: |
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "::error::jq not available on the runner; cannot filter SARIF."
+            exit 1
+          fi
+          # Word-split SUPPRESSED_RULES intentionally — one rule per line for the
+          # jq -R/-s pipeline. shellcheck's default "quote to prevent globbing"
+          # rule (SC2086) would break this.
+          # shellcheck disable=SC2086
+          rules_json=$(printf '%s\n' $SUPPRESSED_RULES | jq -R . | jq -s .)
+          jq \
+            --argjson suppressed "$rules_json" \
+            --arg pinKinds "$SUPPRESSED_PIN_KINDS" \
+            '
+              .runs |= map(
+                .results |= map(select(
+                  (.ruleId // "") as $r
+                  | (.message.text // "") as $t
+                  | (($suppressed | index($r)) == null)
+                    and not ($r == "PinnedDependenciesID" and ($t | test($pinKinds)))
+                ))
+              )
+            ' results.sarif > results.filtered.sarif
+          before=$(jq '[.runs[].results[]] | length' results.sarif)
+          after=$(jq '[.runs[].results[]] | length' results.filtered.sarif)
+          echo "Scorecard SARIF results: $before -> $after after suppression"
+          mv results.filtered.sarif results.sarif
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,17 +2,19 @@
 # https://docs.zizmor.sh/configuration/
 #
 # Accepted suppressions (reason required per the maintenance policy):
-#   - unpinned-uses:      the fleet pins actions to floating major-version TAGS
-#                         (actions/checkout@v7), not commit hashes — a deliberate
-#                         maintenance decision (repo-template #425). `ref-pin`
-#                         accepts a tag/branch ref, so tag pins are clean and only
-#                         a mutable-branch/no-ref pin is flagged.
+#   - unpinned-uses:      every action is SHA-pinned (see fleet convention
+#                         adopted in #187 / OSSF Scorecard #184). `ref-pin`
+#                         accepts either a tag or a commit hash, so SHA-pins
+#                         pass cleanly; only a mutable-branch / no-ref pin
+#                         is flagged.
 #   - dangerous-triggers: pr.yaml uses `pull_request_target` ON PURPOSE so the
 #                         workflow definition comes from main (a PR branch cannot
 #                         weaken its own CI). The risk is mitigated by the
 #                         "Detect .NET Projects" job, which fetches every trusted
 #                         config file from main and never checks out PR code into
-#                         a privileged context. Intentional and reviewed.
+#                         a privileged context. Intentional and reviewed; the
+#                         matching OSSF Scorecard `DangerousWorkflowID` finding
+#                         is suppressed at the SARIF layer in scorecard.yml.
 rules:
   unpinned-uses:
     config:


### PR DESCRIPTION
## Summary

Follow-up to #187 (SHA-pin every action). Addresses the remaining OSSF Scorecard alerts that are structurally wrong for this repo, so subsequent weekly `scorecard.yml` runs don't repeatedly re-create them. Stacked on top of #187.

Together, the two PRs bring open Scorecard alerts from **76 → ~2** on this repo (target was < 25).

Refs #184.

## What's suppressed and why

**Whole-rule** — five checks that are always wrong here:

| Rule | Count | Why false-positive |
|---|--:|---|
| `DangerousWorkflowID` | 8 | `pr.yaml` deliberately uses `pull_request_target` for its protected-config-file guard; workflow YAML comes from trusted `main`, PR head is scan input only. See the `pr.yaml` SECURITY NOTE header (and `.github/zizmor.yml`, which waives `dangerous-triggers` on `pr.yaml` for the same reason). |
| `BranchProtectionID` | 1 | Solo-maintainer repo: approver / codeowner / last-push-approval would force admin-bypass on every PR without adding a real review gate. |
| `CodeReviewID` | 1 | Same underlying reason — solo maintainer self-merges after CI. |
| `CIIBestPracticesID` | 1 | External `bestpractices.dev` registration; not CI-fixable. |
| `FuzzingID` | 1 | No fuzz-test integration on this small adapter library; Scorecard's heuristic detects only OSS-Fuzz / ClusterFuzzLite. |

**Sub-check** on `PinnedDependenciesID` (partial rule — matched via message text):

| Sub-check | Count | Why suppressed |
|---|--:|---|
| `nugetCommand not pinned` | 4 | `dotnet tool install` (ReSharper CLT, reportgenerator, DevSkim) and `dotnet restore` are not hash-pinned. Every csproj already uses explicit `PackageReference` Versions ("no floating"), Dependabot's `nuget` ecosystem bumps transitives weekly, and no repo in the fleet ships `packages.lock.json`. Adopting `--locked-mode` fleet-wide is a separate decision. |
| `pipCommand not pinned` | 0 (future-proof) | No pip installs today, but if any get added (semgrep, zizmor `requirements.txt`, etc.) they'd be dev-time SAST tooling installed from PyPI over HTTPS with signed packages. |

## NOT suppressed (real actionable signal)

- `gitHubAction not pinned by hash` (PinnedDependenciesID) — any regression to a bare `@vN` ref should still fire. The filter is scoped to nuget/pip sub-checks only.
- `CITestsID` (9/10) — recover the last 10% by re-running any failed CI on outstanding PRs so every commit has a passing CI record.
- `SASTID` (9/10) — one older commit escaped CodeQL when the workflow was first introduced.

## Why a SARIF filter instead of `gh api ... dismiss`

Scorecard emits a fresh SARIF each weekly run and the fingerprint drifts enough that individual `gh api -X PATCH .../code-scanning/alerts/{N}` dismissals don't survive one cycle. Filtering at the SARIF layer BEFORE upload is durable: the alerts never enter the code-scanning system on subsequent scans.

The `scorecard.dev` score published to the OpenSSF transparency log (README badge) is unaffected — this only trims the code-scanning-tab noise. The scorecard-action still computes and uploads the full score.

## Also updated

- `.github/zizmor.yml` — refreshes the stale rationale comment ("the fleet pins actions to floating major-version TAGS") to reflect the new SHA-pin policy from #187. Rule config is unchanged: `ref-pin` accepts both tag and SHA refs, so no workflow needs re-editing.

## Filter correctness

Verified locally with a Python simulation against the live `scorecard.yml` SARIF (76 open alerts on `main`):

- Before: 76 alerts
- After: 60 alerts (16 dropped: 8 DangerousWorkflow + 4 nuget + 1 each Branch/Code/CII/Fuzzing)
- After #187 also lands: 58 of the 60 survivors (all `gitHubAction` pin regressions) also disappear, leaving 2 open alerts (CITestsID + SASTID)

**Synthetic regression test**: a fresh `gitHubAction not pinned by hash` result **survives** the filter — the guard against regression stays live.

The step has an explicit `command -v jq` guard with a clear error if the Ubuntu-runner tooling ever drops jq.

## Test plan

- [ ] Admin-bypass merge #187 first (SHA-pin PR)
- [ ] Rebase this branch onto `main` (should be no-op — no line overlap)
- [ ] Admin-bypass merge this PR
- [ ] Trigger `scorecard.yml` (push to main / manual dispatch) and watch the "Filter suppressed findings from SARIF" step log `Scorecard SARIF results: N -> 2 after suppression`
- [ ] Verify `gh api repos/Chris-Wolfgang/Extensions-Logging-Data/code-scanning/alerts?tool_name=Scorecard&state=open --jq 'length'` returns ~2
- [ ] Close umbrella #184 with links to both PRs

## Notes for the maintainer

- **Only touches `.github/workflows/scorecard.yml` and `.github/zizmor.yml`**; the workflows guard fires on `scorecard.yml`. Admin-bypass expected per `feedback_protected_config_files_guard`.
- The filter script matches the canonical pattern applied to ETL-FixedWidth in Chris-Wolfgang/ETL-FixedWidth#316, with the rationale text adapted for this repo (no fuzz tests here, no pip/semgrep in workflows, dev-time tool list is different).

🤖 Generated with [Claude Code](https://claude.com/claude-code)