### PR TITLE
fix(security): jq `not` is a postfix filter, not a prefix operator (#184)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -115,6 +115,10 @@ jobs:
           # rule (SC2086) would break this.
           # shellcheck disable=SC2086
           rules_json=$(printf '%s\n' $SUPPRESSED_RULES | jq -R . | jq -s .)
+          # jq's `not` is a POSTFIX filter, not a prefix operator — the correct
+          # form is `(EXPR) | not`, never `not (EXPR)`. Using `and not (...)`
+          # yields "jq: error: not/1 is not defined at <top-level>" and the
+          # step exits 3 without writing any output.
           jq \
             --argjson suppressed "$rules_json" \
             --arg pinKinds "$SUPPRESSED_PIN_KINDS" \
@@ -124,7 +128,7 @@ jobs:
                   (.ruleId // "") as $r
                   | (.message.text // "") as $t
                   | (($suppressed | index($r)) == null)
-                    and not ($r == "PinnedDependenciesID" and ($t | test($pinKinds)))
+                    and (($r == "PinnedDependenciesID" and ($t | test($pinKinds))) | not)
                 ))
               )
             ' results.sarif > results.filtered.sarif


### PR DESCRIPTION
## Summary

The SARIF-filter step added in #188 uses `and not (EXPR)`, but jq rejects that at parse time — `not` is a 0-arity postfix filter (`(EXPR) | not`), never a prefix operator. Every `scorecard.yml` run since #188 landed has failed at this step with:

```
jq: error: not/1 is not defined at <top-level>
jq: 1 compile error
##[error]Process completed with exit code 3
```

That means none of the "won't-fix" suppressions ever reached code-scanning — the whole 76-alert set is still open on this repo (verified: `gh api ... /code-scanning/alerts?state=open` shows 74 today).

## The fix

One-line change to the jq expression:

```diff
-  and not ($r == "PinnedDependenciesID" and ($t | test($pinKinds)))
+  and (($r == "PinnedDependenciesID" and ($t | test($pinKinds))) | not)
```

Plus a guard comment so the pattern isn't reintroduced.

## Local verification

Installed jq 1.7.1 locally (matches Ubuntu-runner version) and tested both expressions against the current live Scorecard SARIF:

| | Buggy | Fixed |
|---|---|---|
| Parse | `jq: 1 compile error`, exit 3 | OK |
| Before | 76 | 76 |
| After  | (never runs) | 60 |

Surviving rules after the fix (before next SHA-pin re-scan):

- 58 × `PinnedDependenciesID` — all `gitHubAction` pins already fixed on main by #187; will disappear on the next Scorecard scan
- 1 × `CITestsID` (9/10, real actionable signal — intentionally not suppressed)
- 1 × `SASTID` (9/10, same)

Predicted stable state after this lands + next Scorecard run: **2 open alerts**.

## Fleet impact

Same bug is present in ETL-FixedWidth's `scorecard.yaml` (the canonical version #188 was patterned on). That repo has been failing at this step since 2026-08-18 — worth a separate one-line fan-out PR.

## Merge

Workflow-file-only change → `Detect .NET Projects` protected-file guard will fail. Admin-bypass expected, matching #187 / #188 / #171.

Refs #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)