### PR TITLE
ci(pack): enable PackageValidation with per-package baselines (#175)

### DIFF
--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/Wolfgang.Extensions.Logging.Data.EntityFramework6.csproj
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/Wolfgang.Extensions.Logging.Data.EntityFramework6.csproj
@@ -11,6 +11,17 @@
 		     the actual release version. -->
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
+		<!-- Package validation: `dotnet pack` runs Microsoft.DotNet.ApiCompat
+		     against the last-published NuGet version so accidental ABI breaks
+		     (removed / renamed / type-changed public members, dropped TFMs)
+		     fail pack instead of shipping. release.yaml's pack-and-validate
+		     job exercises this at release time. Baseline must be bumped to
+		     the newest published version after every release — that's the
+		     "post-deploy baseline bump PR" step in the per-repo release flow.
+		     EF6 lags the main package's cadence — baseline is the last EF6
+		     release (0.2.0), not the current Data release. -->
+		<EnablePackageValidation>true</EnablePackageValidation>
+		<PackageValidationBaselineVersion>0.2.0</PackageValidationBaselineVersion>
 		<Title>$(AssemblyName)</Title>
 		<Description>Passive structured logging of every Entity Framework 6 command, connection, and transaction event via the EF6 interceptor pipeline. Register once at startup with AddLoggingInterceptors; delegates to Wolfgang.Extensions.Logging.Data for rendering and secret redaction.</Description>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/Extensions-Logging-Data</PackageProjectUrl>

--- a/src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj
+++ b/src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj
@@ -11,6 +11,15 @@
 		     the actual release version. -->
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
+		<!-- Package validation: `dotnet pack` runs Microsoft.DotNet.ApiCompat
+		     against the last-published NuGet version so accidental ABI breaks
+		     (removed / renamed / type-changed public members, dropped TFMs)
+		     fail pack instead of shipping. release.yaml's pack-and-validate
+		     job exercises this at release time. Baseline must be bumped to
+		     the newest published version after every release — that's the
+		     "post-deploy baseline bump PR" step in the per-repo release flow. -->
+		<EnablePackageValidation>true</EnablePackageValidation>
+		<PackageValidationBaselineVersion>0.3.0</PackageValidationBaselineVersion>
 		<Title>$(AssemblyName)</Title>
 		<Description>Extension methods for ILogger and ILogger&lt;T&gt; that log DbConnection, DbCommand, DbParameter, and DbParameterCollection from System.Data.Common, with built-in secret redaction (passwords in connection strings, configurable parameter values).</Description>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/Extensions-Logging-Data</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Adds the fleet-standard `PackageValidation` gate to both shipped csprojs so `dotnet pack` runs Microsoft.DotNet.ApiCompat against the last-published NuGet version. Accidental ABI breaks — removed / renamed / type-changed public members, dropped TFMs — fail pack instead of shipping.

Fleet precedent: Try-Pattern Chris-Wolfgang/Try-Pattern#319 (same pattern, same rationale comment).

Closes #175.

## Baselines (per current NuGet state)

| Package | Latest published | Baseline |
|---|---|---|
| `Wolfgang.Extensions.Logging.Data` | 0.3.0 | **0.3.0** |
| `Wolfgang.Extensions.Logging.Data.EntityFramework6` | 0.2.0 | **0.2.0** |

EF6 lags the main package's cadence (last EF6 release was 0.2.0 while Data is at 0.3.0), so the two csprojs pin different baselines. Each will bump independently after its next release, tracked by the maintenance-step comment.

## Local validation

`dotnet pack -c Release -v:normal` on both projects:

```
RunPackageValidation:
  APICompat ran successfully without finding any breaking changes.
```

No ABI breaks between current main and either baseline — no code changes needed for this to land.

## Maintenance step this institutes

Every future release should bump `<PackageValidationBaselineVersion>` to whatever version just shipped, as a post-deploy PR — per `feedback_post_deploy_baseline_bump` and `reference_packagevalidation_baseline_timing`. Comment in each csproj records this so a future maintainer sees it without hunting.

## Test plan

- [x] `dotnet pack -c Release -v:normal` on both csprojs — validation ran, zero breaks
- [ ] CI: `Reproducible Build` job packs and should also succeed
- [ ] `release.yaml` (when the next release cuts) exercises the gate at release time — nothing to test here until then

## Notes for the maintainer

- **No workflow files touched** → protected-file guard does NOT fire. Standard PR flow (no admin bypass needed).
- Two src csprojs, one XML block per project (~12 lines of comment + 2 lines of properties each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)