### PR TITLE
docs(security): document SBOM + SLSA attestation verification (#90)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,75 @@ We will acknowledge your report within 48 hours and provide an estimated timelin
 Your help is greatly appreciated!
 Responsible disclosure of security vulnerabilities helps protect our entire community.
 
+## Supply-Chain Verification
+
+This section documents how consumers can verify that a published NuGet
+package was genuinely built from this repository by the `release.yaml`
+workflow.
+
+### SBOM (Software Bill of Materials)
+
+Every release attaches a CycloneDX SBOM per shipped package to the GitHub
+Release assets:
+
+- `Wolfgang.Extensions.Logging.Data.bom.json`
+- `Wolfgang.Extensions.Logging.Data.EntityFramework6.bom.json`
+
+Each SBOM lists every NuGet dependency and its version.
+
+To audit the dependency graph:
+
+1. Download the `.bom.json` file(s) from the GitHub Release page.
+2. Open in any CycloneDX-compatible tool (e.g.,
+   [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli),
+   [OWASP Dependency-Track](https://dependencytrack.org/)).
+3. Cross-reference component licenses and versions against your own policy.
+
+### SLSA Build Provenance Attestation
+
+Every release generates a **SLSA Build Level 2** provenance attestation
+signed via [Sigstore](https://sigstore.dev/) keyless signing through
+GitHub's OIDC identity. The attestation proves that the `.nupkg` / `.snupkg`
+files were produced by the `release.yaml` workflow at a specific commit in
+this repository — with no opportunity for an attacker to inject artifacts
+without leaving a verifiable audit trail.
+
+**To verify a package:**
+
+1. Install the [GitHub CLI](https://cli.github.com/) (v2.49.0+).
+2. Download the `.nupkg` from NuGet or the GitHub Release page.
+3. Run:
+
+   ```sh
+   gh attestation verify Wolfgang.Extensions.Logging.Data.<version>.nupkg \
+     --owner Chris-Wolfgang \
+     --repo Extensions-Logging-Data
+   ```
+
+   Or for the EF6 companion package:
+
+   ```sh
+   gh attestation verify Wolfgang.Extensions.Logging.Data.EntityFramework6.<version>.nupkg \
+     --owner Chris-Wolfgang \
+     --repo Extensions-Logging-Data
+   ```
+
+4. A successful verification prints the signing workflow, commit SHA, and
+   Sigstore transparency log entry. Failure means the artifact cannot be
+   traced to a legitimate release run.
+
+### Package Signing (deferred)
+
+NuGet package signing via a code-signing certificate (or Sigstore `cosign`)
+is **not yet implemented** — tracked as
+[#181](https://github.com/Chris-Wolfgang/Extensions-Logging-Data/issues/181),
+blocked on obtaining a code-signing certificate. SLSA attestation via
+`gh attestation verify` provides an equivalent supply-chain integrity
+guarantee for most scenarios.
+
+Once implemented, consumers will be able to run `dotnet nuget verify` to
+check the embedded signature independently of the GitHub CLI.
+
 ## Release path & compromise scope
 
 Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook.


### PR DESCRIPTION
## Summary

Closes the last acceptance criterion of #90 — a documented procedure in `SECURITY.md` that explains how consumers verify the supply-chain integrity of published packages.

The mechanics were already in place:
- `release.yaml` runs `dotnet CycloneDX` for each shipped csproj → `.bom.json` files attached to the release
- `actions/attest-build-provenance` signs each `.nupkg` / `.snupkg`

The v0.3.0 release assets confirm both `.bom.json` files ship. What was missing was the consumer-facing "how to verify" walkthrough; without it the attestation exists but nobody knows to run `gh attestation verify`.

Closes #90.

## What the section covers

- **SBOM** — download the CycloneDX `.bom.json` per package from the GitHub Release, open in a CycloneDX tool (CLI or Dependency-Track), audit dependency licenses/versions
- **SLSA provenance** — `gh attestation verify <pkg>.nupkg --owner Chris-Wolfgang --repo Extensions-Logging-Data`; successful verify proves the artifact traces back to a specific commit + workflow run in this repo
- **Package signing (deferred)** — cross-links #181 so readers see it's tracked, not forgotten

## Fleet-canonical wording

Adapted from ETL-Json's SECURITY.md (which followed ETL-FixedWidth's earlier version), with two changes for this repo:

- SBOM section names **both** shipped packages (Data + EF6) since this repo ships two `.bom.json` files per release, not one
- `gh attestation verify` example shown once per package for copy-paste ergonomics

## Placement

Inserted BEFORE the existing "Release path & compromise scope" section — verification is consumer-facing and belongs near the top of the security-relevant content; the runbook is maintainer-facing and stays at the bottom.

## Test plan

- [x] Docs-only change, no CI risk
- [x] Rendered locally in preview; headings, code fences, links look right
- [ ] After merge: try `gh attestation verify Wolfgang.Extensions.Logging.Data.0.3.0.nupkg --owner Chris-Wolfgang --repo Extensions-Logging-Data` against the actually-published v0.3.0 package to sanity-check the documented command works as written

🤖 Generated with [Claude Code](https://claude.com/claude-code)