### PR TITLE
docs(changelog)+test: fill v0.3.1 gaps + drop redundant MEL.Abstractions pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ floor, adds a build-time ABI gate, and hardens the release pipeline.
   `net462;net48;netstandard2.1` triad) are skipped; their PDBs ship in
   their own package and are covered by that package's SourceLink. (#171)
 
+- **`SECURITY.md` release-path & compromise-scope appendix.** A concise
+  runbook a maintainer would need at 2am if the release identity is
+  compromised: the OIDC trust boundary (Trusted Publishing has no
+  long-lived NuGet API key to rotate), the two-package coordinates for
+  unlisting on nuget.org, and the ownership/downstream-consumer facts.
+  Generic incident-response steps (rotating credentials, publishing
+  advisories) intentionally aren't duplicated here — GitHub's and
+  NuGet's own docs update faster than a checked-in runbook. (#102)
+
 ### Changed
 
 - **`Microsoft.Extensions.Logging.Abstractions` floor bumped to 10.0.11**
@@ -58,7 +67,26 @@ floor, adds a build-time ABI gate, and hardens the release pipeline.
   the `MA0009` double-report. Result: `PR Checks v3 (Gated)` reports 0
   InspectCode findings on a clean build. (#136)
 
+- **README `Supported Frameworks` section standardized** to the
+  fleet-canonical badge collection and target-framework matrix.
+  Consumers scanning the README can now match this repo's TFM story
+  against the same shape used across the `Wolfgang.*` family. (#174)
+
+- **Redundant `Microsoft.Extensions.Logging.Abstractions`
+  `PackageReference` removed from `Tests.Unit`.** The pin was already
+  provided transitively via the `ProjectReference` to the src project;
+  the explicit duplicate caused an NU1605 downgrade every time src's
+  floor bumped (seen on #183 and #186, both hand-fixed post-merge).
+  Test-project-only change — nothing shipped changes.
+
 ### Security
+
+- **Migrated NuGet publish to Trusted Publishing (OIDC).** The
+  `release.yaml` workflow no longer relies on a long-lived NuGet API
+  key stored in GitHub secrets; instead `NuGet/login@v1` mints an
+  ephemeral push token per run via the workflow's OIDC identity
+  (`Chris-Wolfgang/Extensions-Logging-Data`). Rotating the release
+  credential is now automatic — there is no key to leak. (#168)
 
 - **SHA-pinned every GitHub Action across all workflows** — fleet
   mitigation for tj-actions-style attacks, applied to `actions/checkout`,

--- a/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.Logging.Data.Tests.Unit/Wolfgang.Extensions.Logging.Data.Tests.Unit.csproj
@@ -16,7 +16,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <!-- Microsoft.Extensions.Logging.Abstractions comes transitively from the
+         src project's ProjectReference below — do NOT re-pin it here. An
+         explicit version here NU1605-downgrades every time src's floor moves
+         (seen on #183 and #186); relying on the transitive keeps the test
+         project always aligned with whatever src ships. -->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Follow-up to #192. Adds four items to the `[Unreleased]` section that the first draft missed, plus a small structural cleanup that permanently prevents a recurring Dependabot friction on this repo.

## CHANGELOG additions

**Security — new top-billing entry:**
- **#168 — Migrated NuGet publish to Trusted Publishing (OIDC)** ⭐ Marquee posture shift for this release. `release.yaml` no longer holds a long-lived NuGet API key; `NuGet/login@v1` mints an ephemeral push token per run via the workflow's OIDC identity. Placed FIRST in the Security section because "no long-lived credential to leak" is a bigger win than SHA-pinning or Scorecard reduction.

**Added:**
- **#102 — SECURITY.md release-path & compromise-scope appendix.** The 2am runbook — OIDC trust boundary, package coordinates for unlisting, ownership facts.

**Changed:**
- **#174 — README Supported Frameworks section standardized** to the fleet-canonical badge + framework matrix.
- **Redundant `Microsoft.Extensions.Logging.Abstractions` `PackageReference` dropped from `Tests.Unit`** (cleanup landed by this same PR — see below).

## Tests.Unit cleanup

`Tests.Unit.csproj` explicitly pinned `Microsoft.Extensions.Logging.Abstractions` even though it already gets that transitively from the `ProjectReference` to the src project. The redundant pin caused NU1605 downgrades every time src's floor bumped:

- #183 — Dependabot bumped src to 10.0.10, Tests.Unit stuck at 10.0.9 → NU1605 → manual bump `78f6269`
- #186 — Dependabot bumped src to 10.0.11, Tests.Unit stuck at 10.0.10 → NU1605 → manual bump `8c15180`

This is the third occurrence in as many months. Dropping the direct pin and relying on the transitive lets Tests.Unit always inherit whatever src ships, permanently ending the cycle. A comment records the rationale so a future contributor doesn't reintroduce the pin.

**Local verification:**
- `dotnet restore` — clean
- `dotnet build -c Release` — 0 errors
- `dotnet test -c Release -f net10.0` — 94 passed, 0 failed, 0 skipped

Test-project-only change; nothing shipped changes.

## Not included and why

- **#172, #176 Dependabot github-actions bumps** — these are pre-#187 tag-pin bumps that were superseded by SHA-pinning. Not consumer-visible; noise.
- **Fleet fan-out to ETL-FixedWidth** — separate PR to a separate repo; explicitly out of scope for this repo's release.

## Test plan

- [x] `dotnet restore` + `dotnet build -c Release` clean
- [x] `dotnet test -c Release` — 94 passed
- [x] CHANGELOG diff reviewed against `git log v0.3.0..main` — no other missed entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)