### PR TITLE
release: v0.3.1 (Data 0.3.0 -> 0.3.1, EF6 0.2.0 -> 0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.3.1] - 2026-08-21
+
 Both packages get this release. `Wolfgang.Extensions.Logging.Data` moves to
 `0.3.1` and `Wolfgang.Extensions.Logging.Data.EntityFramework6` moves to
 `0.2.1`. No public API changes on either package — this is a
@@ -218,7 +232,8 @@ Initial release.
 - Multi-targeting: `net462`, `netstandard2.0`, `netstandard2.1`,
   `net10.0`.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/Chris-Wolfgang/Extensions-Logging-Data/compare/v0.1.0...v0.1.1

--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/Wolfgang.Extensions.Logging.Data.EntityFramework6.csproj
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/Wolfgang.Extensions.Logging.Data.EntityFramework6.csproj
@@ -3,7 +3,7 @@
 		<TargetFrameworks>net462;net48;netstandard2.1</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-		<Version>0.2.0</Version>
+		<Version>0.2.1</Version>
 		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 		     do not need to recompile / add binding redirects on every minor/patch
 		     bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj
+++ b/src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj
@@ -3,7 +3,7 @@
 		<TargetFrameworks>net462;netstandard2.0;netstandard2.1;net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-		<Version>0.3.0</Version>
+		<Version>0.3.1</Version>
 		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 		     do not need to recompile / add binding redirects on every minor/patch
 		     bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
## Summary

Release-ready state for **v0.3.1**. Both packages ship this release — maintenance-only patch, no public API changes on either.

| Package | Was | Now |
|---|---|---|
| `Wolfgang.Extensions.Logging.Data` | 0.3.0 | **0.3.1** |
| `Wolfgang.Extensions.Logging.Data.EntityFramework6` | 0.2.0 | **0.2.1** |

Sits on top of the [Unreleased] block filled in by #192 + #193 (SHA-pinning, Scorecard 76→2, PackageValidation gate, SBOM/SLSA verify docs, SourceLink workflow, MEL.Abstractions 10.0.11 floor, OIDC Trusted Publishing note, InspectCode noise floor to zero, Tests.Unit redundant-pin cleanup).

## Changes in this PR

1. **`CHANGELOG.md`** — renamed the `[Unreleased]` block filled by #192 + #193 to `## [0.3.1] - 2026-08-21`; added compare-link footer `[0.3.1]: .../compare/v0.3.0...v0.3.1`; re-opened an empty `[Unreleased]` block above the dated section with the standard Keep-a-Changelog subsections.
2. **`<Version>` bumps** in both src csprojs (Data 0.3.0 → 0.3.1, EF6 0.2.0 → 0.2.1).

## What is deliberately NOT in this PR

- **`PackageValidationBaselineVersion` bump.** Baselines stay at `0.3.0` (Data) and `0.2.0` (EF6) for this release, so PackageValidation runs against the actually-last-published version. Bump the baseline to `0.3.1` / `0.2.1` in a **post-deploy PR** after v0.3.1 is on NuGet, per `reference_packagevalidation_baseline_timing` / `feedback_post_deploy_baseline_bump`.
- **`gh release create`.** Per `feedback_no_create_releases`, the release/tag is your action after this PR merges. `release.yaml` triggers on `release:published` and will pack + publish both packages via OIDC Trusted Publishing.

## Local verification

- `dotnet pack -c Release` on both projects produces the correctly-named `.0.3.1.nupkg` / `.0.2.1.nupkg` (+ matching `.snupkg`).
- PackageValidation runs successfully against `0.3.0` / `0.2.0` baselines with **zero breaking-change findings** (`RunPackageValidation: APICompat ran successfully without finding any breaking changes` for both).

## Post-merge steps for you

1. Create the `v0.3.1` release on GitHub against the merge commit (release notes can be lifted verbatim from the `[0.3.1]` CHANGELOG section).
2. `release.yaml` fires, packs + publishes both packages to NuGet via OIDC.
3. Once both packages are live on NuGet, open the post-deploy baseline-bump PR:
   - `PackageValidationBaselineVersion` in Data csproj: `0.3.0` → `0.3.1`
   - `PackageValidationBaselineVersion` in EF6 csproj: `0.2.0` → `0.2.1`

## Test plan

- [x] Bumps applied; `git diff` is exactly the 3 files (CHANGELOG + 2 csprojs)
- [x] `dotnet pack -c Release` on both projects — success, correctly-versioned artifacts, zero PackageValidation findings
- [x] Normal PR flow (no protected files touched) — `Detect .NET Projects` will pass, no admin-bypass needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)