### PR TITLE
chore(pack): bump PackageValidationBaselineVersion to just-shipped v0.3.1

### DIFF
--- a/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/Wolfgang.Extensions.Logging.Data.EntityFramework6.csproj
+++ b/src/Wolfgang.Extensions.Logging.Data.EntityFramework6/Wolfgang.Extensions.Logging.Data.EntityFramework6.csproj
@@ -21,7 +21,7 @@
 		     EF6 lags the main package's cadence — baseline is the last EF6
 		     release (0.2.0), not the current Data release. -->
 		<EnablePackageValidation>true</EnablePackageValidation>
-		<PackageValidationBaselineVersion>0.2.0</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>0.2.1</PackageValidationBaselineVersion>
 		<Title>$(AssemblyName)</Title>
 		<Description>Passive structured logging of every Entity Framework 6 command, connection, and transaction event via the EF6 interceptor pipeline. Register once at startup with AddLoggingInterceptors; delegates to Wolfgang.Extensions.Logging.Data for rendering and secret redaction.</Description>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/Extensions-Logging-Data</PackageProjectUrl>

--- a/src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj
+++ b/src/Wolfgang.Extensions.Logging.Data/Wolfgang.Extensions.Logging.Data.csproj
@@ -19,7 +19,7 @@
 		     the newest published version after every release — that's the
 		     "post-deploy baseline bump PR" step in the per-repo release flow. -->
 		<EnablePackageValidation>true</EnablePackageValidation>
-		<PackageValidationBaselineVersion>0.3.0</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>0.3.1</PackageValidationBaselineVersion>
 		<Title>$(AssemblyName)</Title>
 		<Description>Extension methods for ILogger and ILogger&lt;T&gt; that log DbConnection, DbCommand, DbParameter, and DbParameterCollection from System.Data.Common, with built-in secret redaction (passwords in connection strings, configurable parameter values).</Description>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/Extensions-Logging-Data</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Post-deploy baseline bump for **v0.3.1** which published cleanly to NuGet a few minutes ago (release.yaml run [32484574928](https://github.com/Chris-Wolfgang/Extensions-Logging-Data/actions/runs/32484574928), all 6 jobs green, no flakes). Both packages now on flatcontainer.

| csproj | baseline was | baseline now |
|---|---|---|
| `Wolfgang.Extensions.Logging.Data` | 0.3.0 | **0.3.1** |
| `Wolfgang.Extensions.Logging.Data.EntityFramework6` | 0.2.0 | **0.2.1** |

From this point every `dotnet pack` runs `Microsoft.DotNet.ApiCompat` against the newest published surface, so any accidental ABI break introduced between v0.3.1 and vNext will fail pack instead of shipping.

## Why now, not in the release PR

Fleet-standard post-deploy sequence per `reference_packagevalidation_baseline_timing` and `feedback_post_deploy_baseline_bump` — the baseline stays at **last-PUBLISHED** across the release itself, then advances in a separate PR once the new version is downloadable from NuGet. Doing it in the release PR would fail `dotnet pack` (the baseline needs to be download-restorable, and it isn't until after the tag fires `release.yaml` and NuGet CDN propagates).

## Local verification

`dotnet pack -c Release -v:normal` on both projects reports `RunPackageValidation: APICompat ran successfully without finding any breaking changes` against the new baselines. Both `.nupkg` / `.snupkg` files pack correctly.

## Test plan

- [x] Both NuGet packages confirmed live on flatcontainer (`Data: [..., 0.3.0, 0.3.1]`, `EF6: [0.2.0, 0.2.1]`)
- [x] `dotnet pack -c Release` on both — PackageValidation runs against new baselines, zero breaking-change findings
- [x] 2-file diff, no version file changes, no workflow file changes → normal PR flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)